### PR TITLE
Fix for 405 - Method Not Allowed when reload

### DIFF
--- a/index.html
+++ b/index.html
@@ -450,7 +450,7 @@
 			}
 		}
 		ws.onclose = () => {
-			if(CD != Infinity)return location.reload()
+			if(CD != Infinity)return location.replace(location.origin)
 			//Something went wrong...
 			CD = 1e100
 		}


### PR DESCRIPTION
When reloading the website (by clicking the reload button, or calling `location.reload()` in javascript) there's a chance the user will get 405 - Method Not Allowed. It's trying to send a POST instead of a GET to the website for some weird reason. This time the user has to open a new tab with the website or just click on the url bar and press enter to "reload" the website, by this way no 405 error will be given.
