### PR TITLE
Fix accidental clipboard copy when using postcopy

### DIFF
--- a/style.css
+++ b/style.css
@@ -1123,6 +1123,8 @@ postcopy span {
 	transform: translateY(-50%);
 	line-height: 24px;
 	transition: 1s opacity;
+	white-space: nowrap;
+	pointer-events: none;
 }
 
 /* Reddit-themed styles ported from the instance manager*/


### PR DESCRIPTION
Especially annoying on mobile where the posts are really skinny so it is hard to not accidentally hit it.