### PR TITLE
Hacky fixes for name impersonation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.key
 
 vip.txt
+reserved_names.txt
 blacklist.txt
 cooldown_overrides.txt
 webhook_url.txt


### PR DESCRIPTION
Using a kind of VIP system for verified names we can now ensure that people using a reserved name while not actually being that person gets a ~ to indicate their lack of authenticity, and a heavy checkmark for legitamate