### PR TITLE
Overload browser cache when loading board

### DIFF
--- a/index.html
+++ b/index.html
@@ -3123,7 +3123,7 @@
         async function fetchBoard() {
             // Override browser cache with ?v= param, may incurr longer loading times
             // TODO: investigate optimisations to onl;y do a hard realod when necessary
-            const response = await fetch((localStorage.board || DEFAULT_BOARD) + "?v=" + Date.now)
+            const response = await fetch((localStorage.board || DEFAULT_BOARD) + "?v=" + Date.now())
             if (!response.ok) {
                 showLoadingScreen()
                 fetchFailTimeout = setTimeout(fetchBoard, fetchCooldown *= 2)

--- a/index.html
+++ b/index.html
@@ -3121,7 +3121,9 @@
         wscapsule()
 
         async function fetchBoard() {
-            const response = await fetch(localStorage.board || DEFAULT_BOARD)
+            // Override browser cache with ?v= param, may incurr longer loading times
+            // TODO: investigate optimisations to onl;y do a hard realod when necessary
+            const response = await fetch((localStorage.board || DEFAULT_BOARD) + "?v=" + Date.now)
             if (!response.ok) {
                 showLoadingScreen()
                 fetchFailTimeout = setTimeout(fetchBoard, fetchCooldown *= 2)


### PR DESCRIPTION
Browser cache is literally a blight, one of the most evil things to ever happen