### PR TITLE
Multiple create post contents upload, link key & persistent placers load

### DIFF
--- a/index.html
+++ b/index.html
@@ -495,6 +495,7 @@
         let chatName = null
         let uploadPost = null // function injected by wscapsule
         let setName = null // function injected by wscapsule
+        let requestPixelPlacers = null // function injected by wscapsule
         let requestLoadChannelPrevious = null // function injected by wscapsule
         let canvasLocked = false // Server will tell us this
         let includesPlacer = false // Server will tell us this
@@ -850,6 +851,23 @@
                     }
                     break
                 }
+                case 9: { // Placer info region
+                    let i = data.getUint32(1)
+                    const regionWidth = data.getUint8(5)
+                    const regionHeight = data.getUint8(6)
+                     
+                    let dataI = 7
+                    while (dataI < data.byteLength) {
+                        for (let xi = i; xi < i + regionWidth; xi++) {
+                            if (dataI != 0xFFFFFFFF) {
+                                intIdPositions.set(xi, data.getUint32(dataI))
+                            }
+                            dataI += 4
+                        }
+                        i += WIDTH
+                    }
+                    break
+                }
                 case 11: { // Player int ID // TODO: Integrate into packet 1
                     intId = data.getUint32(1)
                     break
@@ -1136,8 +1154,9 @@
                         console.error("Could not resolve link key, request object was null")
                         break
                     }
-                    const linkKey = decoder.decode(data.buffer.slice(1))
-                    linkKeyRequest.resolve(linkKey)
+                    const instanceId = data.getUint32(1)
+                    const linkKey = decoder.decode(data.buffer.slice(5))
+                    linkKeyRequest.resolve({ linkKey, instanceId: 1 })
                     break
                 }
                 }
@@ -1179,7 +1198,7 @@
                 linkKeyRequest = new PublicPromise()
                 call(send, ws, new Uint8Array([110]))
                 const linkInfo = await linkKeyRequest.promise
-                postData.canvasUser = linkInfo
+                postData.canvasUser = linkInfo // { linkKey: number, instanceId: number }
 
                 const uploadResponse = await fetch(`${localStorage.auth || DEFAULT_AUTH}/posts/upload`, {
                     method: "POST",
@@ -1212,10 +1231,21 @@
                 if (uname.length > 16) return
                 uname ||= "anon"
 
-                let nameBuf = encoder.encode("\x0C" + uname)
+                const nameBuf = encoder.encode("\x0C" + uname)
                 call(send, ws, nameBuf)
             }
             setName = _setName
+
+            // Requests all the pixel placers for a given region from the server to be loaded into 
+            function _requestPixelPlacers(x, y, width, height) {
+                const placerInfoBuf = new DataView(new Uint8Array(7).buffer)
+                placerInfoBuf.setUint8(0, 9)
+                placerInfoBuf.setUint32(1, x + y * WIDTH)
+                placerInfoBuf.setUint8(5, width)
+                placerInfoBuf.setUint8(6, height)
+                call(send, ws, placerInfoBuf)
+            }
+            requestPixelPlacers = _requestPixelPlacers
 
             function put() {
                 // If CD is null but we have already made that initial connection, we have likely ghost disconnected from the WS
@@ -2873,8 +2903,13 @@
                 idPositionTimeout = setTimeout(() => {
                     idPositionDebounce = false
                     let id = intIdPositions.get(intX + intY * WIDTH)
-                    if (id === undefined) return
-
+                    if (id === undefined) {
+                        // Request 16x16 region of pixel placers from server (fine tune if necessary)
+                        const placersRadius = 16
+                        requestPixelPlacers(Math.max(intX - placersRadius / 2, 0), Math.max(intY - placersRadius / 2),
+                            Math.min(placersRadius, WIDTH - intX), Math.min(placersRadius, HEIGHT - intY))
+                        return
+                    }
                     idPosition.style.display = "flex"
                     idPosition.style.left = intX + "px"
                     idPosition.style.top = intY + "px"

--- a/index.html
+++ b/index.html
@@ -1679,7 +1679,7 @@
     <meta name="apple-mobile-web-app-title" content="place">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link href="style.css?v=3.37" rel="stylesheet"> <!-- Increment the CSS query, such as ?v=1.x every time CSS is changed in order to force clients to refresh their stylesheets. Otherwise broken CSS may occur-->
+    <link href="style.css?v=3.38" rel="stylesheet"> <!-- Increment the CSS query, such as ?v=1.x every time CSS is changed in order to force clients to refresh their stylesheets. Otherwise broken CSS may occur-->
     <title>place</title>
     <link rel="icon" type="image/x-icon" href="favicon.png">
 <meta property="og:title" content="r/place 2"/>

--- a/index.html
+++ b/index.html
@@ -1178,11 +1178,8 @@
                 // Link key to prove we own this account ID
                 linkKeyRequest = new PublicPromise()
                 call(send, ws, new Uint8Array([110]))
-                const linkKey = await linkKeyRequest.promise
-                postData.canvasUser = {
-                    linkKey: linkKey,
-                    instanceId: 1 // Canvas 1 (for now)
-                }
+                const linkInfo = await linkKeyRequest.promise
+                postData.canvasUser = linkInfo
 
                 const uploadResponse = await fetch(`${localStorage.auth || DEFAULT_AUTH}/posts/upload`, {
                     method: "POST",
@@ -1197,11 +1194,11 @@
                 }
 
                 // Upload file as form content
-                if (createPostContent.length != 0) {
+                for (const file of createPostContent.contents) {
                     const data = await uploadResponse.json()
                     const contentForm = new FormData() // new Blob([], { type: "text/plain" })
                     contentForm.append("contentUploadKey", data.contentUploadKey)
-                    contentForm.append("file", createPostContent[0])
+                    contentForm.append("file", file)
 
                     const contentResponse = await fetch(`${localStorage.auth || DEFAULT_AUTH}/posts/${data.postId}/content/`, {
                         method: "POST",
@@ -2006,9 +2003,10 @@
                     event.stopPropagation()
                     event.preventDefault()
                     this.classList.remove('image-drop')
-                    const file = event.dataTransfer.files[0]
-                    if (file && file.type.startsWith('image/')) {
-                        appendPostContent(file)
+                    for (const file of event.dataTransfer.files) {
+                        if (file.type.startsWith('image/')) {
+                            createPostContent.addContent(file)
+                        }
                     }
                 " ondragleave="
                     event.stopPropagation()
@@ -2040,17 +2038,17 @@
                             </svg>
                         </button>
                         <input type="file" id="createPostContentInput" accept="image/*" onchange="
-                            if (this.files[0]) {
-                                appendPostContent(this.files[0])
+                            for (const file of this.files) {
+                                createPostContent.addContent(file)
                             }
                         " style="display: none;">
                     </div>
                     <div id="createPostOptions" class="create-post-extra">
-                        <div id="createPostContentPreview" style="flex-grow: 1;"></div>
+                        <r-post-contents-preview id="createPostContent"></r-post-contents-preview>
                         <button class="post-button discard-post-button" onclick="
                             createPostTitle.value = ''
                             createPostInput.value = ''
-                            clearPostContent()
+                            createPostContent.clearContents()
                             createPostInput.placeholder = 'Create post...'
                             createPostPost.classList.remove('focused')
                         ">Discard</button>
@@ -3447,25 +3445,6 @@
                     messageInput.setAttribute("state", "default")
                     handled = true
                 }
-            }
-        }
-
-        const createPostContent = []
-        function appendPostContent(file) {
-            createPostContentPreview.innerHTML = ""
-            const label = document.createElement("span")
-            label.textContent = "Content upload:"
-            createPostContentPreview.appendChild(label)
-            const img = document.createElement("img")
-            img.src = window.URL.createObjectURL(file)
-            createPostContentPreview.appendChild(img)
-            createPostContent.push(file)
-        }
-
-        function clearPostContent() {
-            createPostContentPreview.innerHTML = ""
-            while (createPostContent.length) {
-                createPostContent.pop()
             }
         }
 

--- a/server.ts
+++ b/server.ts
@@ -112,7 +112,7 @@ try {
     BOARD = new Uint8Array(await Bun.file(path.join(PUSH_PLACE_PATH, "place")).arrayBuffer())
 }
 catch(e) {
-    console.log(e, "regenerating")
+    console.log(e, ", regenerating")
     BOARD = new Uint8Array(WIDTH * HEIGHT)
 }
 try {
@@ -124,21 +124,21 @@ try {
         throw new Error("Changes was smaller than expected")
 }
 catch(e) {
-    console.log(e, "regenerating")
+    console.log(e, ", regenerating")
     CHANGES = new Uint8Array(WIDTH * HEIGHT).fill(255)
 }
 try {
     PLACERS = new Uint32Array(await Bun.file(path.join(PUSH_PLACE_PATH, "placers")).arrayBuffer())
 }
 catch(e) {
-    console.log(e, "regenerating")
+    console.log(e, ", regenerating")
     PLACERS = new Uint32Array(WIDTH * HEIGHT).fill(0xFFFFFFFF)
 }
 try {
     VOTES = new Uint32Array(await Bun.file("./votes").arrayBuffer())
 }
 catch(e) {
-    console.log(e, "regenerating")
+    console.log(e, ", regenerating")
     VOTES = new Uint32Array(32)
 }
 let uidTokenFailed = false
@@ -910,6 +910,31 @@ const serverOptions:TLSWebSocketServeOptions<ClientData> = {
                     postDbMessage("updatePixelPlace", ws.data.intId)
                     break
                 }
+                case 9: { // Get region pixel placer info
+                    if (!INCLUDE_PLACER) {
+                        return
+                    }
+                    let boardI = data.readUInt32BE(1)
+                    const startX = boardI % WIDTH
+                    const startY = Math.floor(boardI / WIDTH) 
+                    const regionWidth = data[5] + startX > WIDTH ? WIDTH - startX : data[5]
+                    const regionHeight = data[6] + startY > HEIGHT ? HEIGHT - startY : data[6]
+
+                    const placerInfoBuf = Buffer.alloc(7 + (regionWidth * regionHeight * 4))
+                    placerInfoBuf[0] = 9
+                    placerInfoBuf.writeUInt32BE(boardI, 1)
+                    placerInfoBuf[5] = regionWidth
+                    placerInfoBuf[6] = regionHeight
+                    for (let pi = 7; pi < placerInfoBuf.byteLength; pi += regionWidth * 4) {
+                        // We need to reinterpret PLACERS as a uint8 array for set to work properly
+                        const placersXLine = PLACERS.subarray(boardI, boardI + regionWidth)
+                        const placersUint8Array = new Uint8Array(placersXLine.buffer, placersXLine.byteOffset, placersXLine.byteLength)
+                        placerInfoBuf.set(placersUint8Array, pi)
+                        boardI += WIDTH
+                    }
+                    ws.send(placerInfoBuf)
+                    break
+                }
                 case 12: { // Submit name
                     let name = decoderUTF8.decode(data.subarray(1))
                     const resName = RESERVED_NAMES.getReverse(name) // reverse = valid code, use reserved name, forward = trying to use name w/out code, invalid
@@ -1278,7 +1303,7 @@ const serverOptions:TLSWebSocketServeOptions<ClientData> = {
                     const w = data[1]
                     let i = data.readUInt32BE(2)
                     const h = Math.floor((data.length - 6) / w)
-                    if (i % WIDTH + w >= WIDTH || i + h * HEIGHT >= WIDTH * HEIGHT) return
+                    if (i % WIDTH + w >= WIDTH || i + h * WIDTH >= WIDTH * HEIGHT) return
 
                     let hi = 6
                     const target = w * h + 6
@@ -1647,7 +1672,9 @@ setInterval(async function () {
         return
     }
     await Bun.write(path.join(PUSH_PLACE_PATH, "change" + (pushTick & 1 ? "2" : "")), CHANGES)
-    await Bun.write(path.join(PUSH_PLACE_PATH, "placers"), PLACERS)
+    if (INCLUDE_PLACER) {
+        await Bun.write(path.join(PUSH_PLACE_PATH, "placers"), PLACERS)
+    }
     if (pushTick % (PUSH_INTERVAL_MINS / 5 * 60) == 0) {
         try {
             await pushImage()

--- a/style.css
+++ b/style.css
@@ -1450,20 +1450,46 @@ up div {
 	opacity: 1;
 	height: 36px;
 }
+#createPostPost.focused #createPostOptions {
+	height: fit-content !important;
+}
 #createPostPost.focused #createPostTitle {
 	margin-bottom: 8px;
 }
-#createPostContentPreview {
+r-post-contents-preview {
+	display: flex;
+	column-gap: 8px;
+	flex-grow: 1;
+	transition: .2s height;
+}
+r-post-contents-preview > span {
+	align-self: center;
+	min-width: min-content;
+}
+r-post-contents-preview > div {
+	overflow-x: scroll;
 	display: flex;
 	column-gap: 8px;
 }
-#createPostContentPreview > span {
-	align-self: center;
+r-create-post-content {
+	position: relative;
+	overflow: clip;
 }
-#createPostContentPreview > img {
-	height: 36px;
+r-create-post-content > img {
+	height: 72px;
 	border: 1px solid gray;
 	border-radius: 4px;
+}
+r-create-post-content > button {
+	position: absolute;
+	left: 0;
+	top: 0;
+	width: 24px;
+	height: 16px;
+	border-radius: 4px 0px 4px 0px;
+	box-shadow: none;
+	padding: 0;
+	background: #000000b8;
 }
 .post-button {
 	border-radius: 64px;


### PR DESCRIPTION
- Small breaking change to linkage API request with server declared instance ID
- Allow client to lazy load PLACERS from the server to see pixel places from before when they connected
- Web component-ise create post contents, allowing maximum of 4 images to be attached,  cleanup code
- Server small cleanups, ROLLBACK packet bounds check fix