### PR TITLE
Massive placechat rendering & positioning upgrades, theme and style improvements

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,10 +69,6 @@
 						<img theme="pixelselect" src="/svg/pixel-select-2022.svg" style="position: absolute; top: -10%; left: -10%; width: 120%; height: 120%" ondragstart="return false">
 					</div>
 					<img id="templateImage" width="auto" height="auto" ondrag="return">
-					<div class="place-chat" id="idPosition" style="display: none;">
-						<span translate="placedBy">Placed by:</span>
-						<span><!--placer name||id--></span>
-					</div>
 				</div>
 				<div id="placeContext" class="context-menu" style="display:none">
 					<menu>
@@ -80,6 +76,16 @@
 						<li><button type="button" id="placeContextInfoButton">Show pixel placer info</button></li>
 						<li id="placeContextModItem"><button type="button" id="placeContextModButton" disabled>Moderate here</button></li>
 					</menu>
+				</div>
+				<div id="placeChatMessages">
+					<!--Container for canvas place chat messages-->
+					<div class="place-chat" id="idPosition" style="display: none;">
+						<div class="content">
+							<span translate="placedBy">Placed by:</span>
+							<span id="idPositionPlacer"><!--placer name||id--></span>
+						</div>
+						<div class="arrow"></div>
+					</div>
 				</div>
 			</div>
 
@@ -478,7 +484,7 @@
 				</p>
 				<div class="modal-footer">
 					<img noselect="" alt="Place Logo" height="40" width="40" src="images/rplace.png" style="position: absolute;left: 50%;transform: translateX(-50%);opacity: 0.2;">
-					<button id="muteButton" noselect class="modal-footer-button" title="Enable sounds">
+					<button type="button" id="muteButton" noselect class="modal-footer-button" title="Enable sounds">
 						<image id="muteButtonImage" class="icon-image" src="/svg/muted.svg"></image>
 					</button>
 					<div id="themeDropParent" noselect class="modal-footer-button" style="width: auto; align-items: center;justify-content: center;"

--- a/public/css/rplace-2022.css
+++ b/public/css/rplace-2022.css
@@ -5,6 +5,7 @@
 	--ui-panel-bg: white;
 	--ui-text: black;
 	--ui-shadow: 0 0 10px rgba(0,0,0,0.4);
+	--ui-border: none;
 }
 
 :root[data-variant="dark"] {
@@ -13,6 +14,7 @@
 	--ui-panel-hover: #313131;
 	--ui-panel-bg: #141414;
 	--ui-text: white;
+	--ui-border: 1px solid var(--ui-panel-hover);
 }
 :root[data-variant="dark"] .icon-image {
 	filter: invert(1);
@@ -102,8 +104,8 @@ input[type="file"]::file-selector-button {
 	padding: 17.5px;
 }
 .labelled-slider .slider-value {
-    width: 30px;
-    height: 30px;
+	width: 30px;
+	height: 30px;
 	box-shadow: 0px 0px 5px rgba(0, 0, 0, 0.5);
 	background: var(--ui-panel-bg);
 	border-radius: 10px;
@@ -350,7 +352,7 @@ r-live-chat-message .emoji-reactors-count {
 }
 .toast-menu .toast-header {
 	background: var(--ui-panel-bg);
-    padding: 10px;
+	padding: 10px;
 }
 .toast-menu .toast-body {
 	padding: 10px;
@@ -549,4 +551,24 @@ r-spoiler[hidden] {
 r-spoiler[hidden]:hover {
 	opacity: 0.8;
 	color: black;
+}
+
+r-place-chat, .place-chat {
+	background: var(--ui-panel-bg);
+	box-shadow: var(--ui-shadow);
+	border-radius: 15px;
+	font-size: 16px;
+	border: var(--ui-border);
+}
+
+r-place-chat .content, .place-chat .content {
+	padding: 8px;
+	column-gap: 8px;
+	border-radius: 15px;
+	background: var(--ui-panel-bg);
+}
+
+r-place-chat .arrow, .place-chat .arrow {
+	background-color: var(--ui-panel-bg);
+	border: var(--ui-border);
 }

--- a/public/css/rplace-2023.css
+++ b/public/css/rplace-2023.css
@@ -496,6 +496,34 @@ r-spoiler[hidden]:hover {
 }
 
 r-place-chat, .place-chat {
-	border-radius: 0px;
-    box-shadow: rgba(0, 0, 0, 0.75) 1px 1px 0px;
+	border: var(--pixel-border);
+	background-color: white;
+}
+
+r-place-chat::after, .place-chat::after {
+	content: "";
+	left: 8px;
+	top: 8px;
+	background-color: rgba(0, 0, 0, 0.75);
+	position: absolute;
+	width: 100%;
+	height: 100%;
+	z-index: -2;
+}
+
+r-place-chat .content, .place-chat .content {
+	padding: 8px;
+	column-gap: 8px;
+	background-color: white;
+}
+
+r-place-chat .arrow, .place-chat .arrow {
+	border: var(--pixel-border);
+	background-color: white;
+}
+
+r-place-chat .arrow::after, .place-chat .arrow::after {
+	content: "";
+	left: 8px;
+	background-color: rgba(0, 0, 0, 0.75);
 }

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -189,8 +189,8 @@ export const LANG_INFOS = new Map([
  * @constant {Map<string, ThemeInfo>} DEFAULT_THEMES
  */
 export const DEFAULT_THEMES = new Map([
-	["r/place 2022", { id: "r/place 2022", css: "/css/rplace-2022.css", cssVersion: "22", pixelselect: "/svg/pixel-select-2022.svg" }],
-	["r/place 2023", { id: "r/place 2023", css: "/css/rplace-2023.css", cssVersion: "22", pixelselect: "/svg/pixel-select-2023.svg" }]
+	["r/place 2022", { id: "r/place 2022", css: "/css/rplace-2022.css", cssVersion: "23", pixelselect: "/svg/pixel-select-2022.svg" }],
+	["r/place 2023", { id: "r/place 2023", css: "/css/rplace-2023.css", cssVersion: "23", pixelselect: "/svg/pixel-select-2023.svg" }]
 ])
 
 /**

--- a/src/pages/index/game-elements.js
+++ b/src/pages/index/game-elements.js
@@ -481,12 +481,15 @@ export class PlaceChat extends LitElement {
 
 	render() {
 		return html`
-			<span title="${(new Date(this.sendDate)).toLocaleString()}" style="color: ${CHAT_COLOURS[hash(String(this.senderIntId)) & 7]};">
-				[${this.senderChatName}]
-			</span>
-			<span>
-				${this.content}
-			</span>`
+			<div class="content">
+				<span title="${(new Date(this.sendDate)).toLocaleString()}" style="color: ${CHAT_COLOURS[hash(String(this.senderIntId)) & 7]};">
+					[${this.senderChatName}]
+				</span>
+				<span>
+					${this.content}
+				</span>
+			</div>
+			<div class="arrow"></div>`
 	}
 }
 customElements.define("r-place-chat", PlaceChat);

--- a/src/shared-elements.js
+++ b/src/shared-elements.js
@@ -136,7 +136,7 @@ class ClipboardCopy extends HTMLElement {
 		})
 	}
 }
-customElements.define("r-clipboard-copy", ClipboardCopy)
+customElements.define("r-clipboard-copy", ClipboardCopy);
 
 class CloseIcon extends HTMLElement {
 	constructor() {

--- a/styles.css
+++ b/styles.css
@@ -1091,7 +1091,7 @@ body[eventphase="3"] .coverer-title {
 	z-index: 5;
 	transform: translateX(-50%);
 	overflow: auto;
-    max-height: calc(100% - 120px);
+	max-height: calc(100% - 120px);
 }
 
 .toast-menu .toast-header {
@@ -1107,7 +1107,7 @@ body[eventphase="3"] .coverer-title {
 
 .toast-menu .toast-body {
 	display: flex;
-    flex-direction: column;
+	flex-direction: column;
 	row-gap: 8px;
 }
 
@@ -1216,7 +1216,7 @@ body[eventphase="3"] .coverer-title {
 	position: absolute;
 	top: 0;
 	left: 0;
-    height: 100%;
+	height: 100%;
 	aspect-ratio: 1/1;
 	text-align: center;
 	pointer-events: none;
@@ -1253,7 +1253,7 @@ body[eventphase="3"] .coverer-title {
 	display: flex;
 	column-gap: 4px;
 	height: min-content;
-    align-items: center;
+	align-items: center;
 }
 
 .avm-view-layers > li {
@@ -1500,39 +1500,42 @@ kbd {
 	border-radius: 0px !important;
 }
 
-r-place-chat, .place-chat {
-	display: flex;
-	column-gap: 1px;
-	background: white;
+#placeChatMessages {
 	position: absolute;
-	height: 4px;
-	border-radius: 1.5px;
-	font-size: 2px;
-	padding: 0px 1px 0px 1px;
-	text-align: center;
 	z-index: 3;
-	box-shadow: 0px 0px 1px black;
-	transform: translateX(-50%) translateY(-150%);
-	max-width: 65px;
-	min-width: 8px;
-	width: max-content;
+	transform-origin: top left;
 }
 
-r-place-chat::after, .place-chat::after {
-	content: " ";
+r-place-chat, .place-chat {
 	position: absolute;
-	top: 100%;
-	left: 50%;
-	margin-left: -2px;
-	border-width: 2px;
-	border-style: solid;
-	border-color: white transparent transparent transparent;
+	display: flex;
+	z-index: 3;
+	transform: translate(calc(-50% + 5px), calc(-50% - 37px));
+	user-select: none;
+	transition: .2s opacity, .2s filter;
 }
 
-r-place-chat span, .place-chat span {
-	color: black;
-	font-size: 2px;
-	align-self: center;
+r-place-chat .content, .place-chat .content {
+	display: flex;
+	width: 100%;
+	height: 100%;
+}
+
+r-place-chat:hover, .place-chat:hover {
+	opacity: 0.2;
+	filter: saturate(0.5);
+}
+
+r-place-chat .arrow, .place-chat .arrow {
+	position: absolute;
+	width: 24px;
+	height: 24px;
+	background: white;
+	transform: translate(-50%, 50%) rotate(45deg);
+	bottom: 0;
+	left: 50%;
+	transform-origin: center;
+	z-index: -1;
 }
 
 #popup {
@@ -1776,7 +1779,7 @@ r-gif-panel footer {
 r-gif {
 	display: block;
 	width: min(100%, 256px);
-    overflow: hidden;
+	overflow: hidden;
 }
 
 r-gif video {
@@ -1829,7 +1832,7 @@ r-gif video {
 
 #editLocalStorageList label {
 	flex-grow: 1;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
 }


### PR DESCRIPTION
Place chat rendering has been updated to render at a 1:1 UI scale, instead of relying on subpixel rendering, fixing multiple issues regarding font positioning, graphical glitches and other rendering artifacts.

Should address long-standing issue on webkit where place and canvas chat appears blury due to rendering at extremely small CSS pixel sizes.

Place chat elements will now go translucent upon mouse hover, reducing visual clutter or interruption caused by place chat, or current pixel placer elements obsctructing canvas view.

This update also improves the positioning of place chat elements to more accurately display above their respective pixel, as well as way better place chat appearances across multiple site themes.

<table>
  <tr>
    <th>Theme</th>
    <th>Old</th>
    <th>New</th>
  </tr>
  <tr>
    <td><strong>2022 Dark</strong></td>
    <td><img src="https://github.com/user-attachments/assets/f05446fc-ee81-432f-85e1-3c97aed66459" width="400" /></td>
    <td><img src="https://github.com/user-attachments/assets/6c623309-d82a-43c0-9639-c8da18ca746e" width="400" /></td>
  </tr>
  <tr>
    <td><strong>2023</strong></td>
    <td><img src="https://github.com/user-attachments/assets/9278407e-3dbf-409b-b5c8-69ae75d15e1a" width="400" /></td>
    <td><img src="https://github.com/user-attachments/assets/6c486d00-2e27-4edd-bd34-c80fde064c12" width="400" /></td>
  </tr>
  <tr>
    <td><strong>2022 Light</strong></td>
    <td><img src="https://github.com/user-attachments/assets/32fd3634-ab41-4e12-8f0a-5916fdc797be" width="400" /></td>
    <td><img src="https://github.com/user-attachments/assets/340e5e39-faf9-410a-ae28-4adf14586f02" width="400" /></td>
  </tr>
</table>
