### PR TITLE
fix: restore game connection startup

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,8 +55,6 @@
 	<script type="module" src="/src/pages/index/index.js"></script>
 	<!--External-->
 	<script src="https://js.hcaptcha.com/1/api.js?render=explicit" async defer></script><!--onload=onloadHCaptcha-->
-	<!--Science!-->
-	<script src="https://blobk.at/science.js" type="module"></script>
 </head>
 	<body>
 		<div id="loadingScreen">

--- a/src/pages/index/game-state.js
+++ b/src/pages/index/game-state.js
@@ -98,6 +98,8 @@ const wsCapsule = new Worker(url, {
 	type: "module"
 });
 let defaultCaptchaHandlers;
+/** @type {[string, number|undefined, number|undefined]|null} */
+let pendingChatHistoryRequest = null;
 const gameIpc = await createGameIpc(
 	wsCapsule,
 	selectedServer,
@@ -164,6 +166,11 @@ const automatedActivityFlags =
 
 function handleGameConnect() {
 	connectStatus = "connected";
+	if (pendingChatHistoryRequest) {
+		const request = pendingChatHistoryRequest;
+		pendingChatHistoryRequest = null;
+		gameIpc.requestChatHistory(...request);
+	}
 }
 addIpcMessageHandler("handleConnect", handleGameConnect);
 function handleStrictPalette(/**@type {[number[],number,number]}*/[palette, start, end]) {
@@ -634,6 +641,10 @@ export function sendServerMessage(name, args=undefined, event=undefined) {
 		return;
 	}
 	if (name === "requestLoadChannelPrevious") {
+		if (connectStatus !== "connected") {
+			pendingChatHistoryRequest = [args.channel, args.anchorMsgId, args.msgCount];
+			return;
+		}
 		gameIpc.requestChatHistory(args.channel, args.anchorMsgId, args.msgCount);
 		return;
 	}


### PR DESCRIPTION
## What changed

- defer the initial chat-history request until the strict game connection reaches its open state
- temporarily remove the failing optional `https://blobk.at/science.js` module

## Root cause

The page requested chat history while `index.js` was still evaluating and before `connect()` ran. The strict IPC adapter correctly rejected the out-of-state command synchronously, which aborted entrypoint evaluation and prevented the game connection from starting.

## Impact

This restores client startup without weakening strict IPC lifecycle enforcement. The latest pre-open chat-history request is sent immediately after connection open.

## Validation

- `bun test` — 30 passed, 0 failed
- `bun run build` — production Vite/PWA build passed
- `git diff --check`
