### PR TITLE
Align WebGL board projection with Canvas2D

### DIFF
--- a/src/pages/index/board-renderer.js
+++ b/src/pages/index/board-renderer.js
@@ -548,8 +548,12 @@ export class BoardRenderer extends EventTarget {
 		const projection = this._projectionMatrix;  
 		const mvp = this._mvpMatrix;
 
-		// Calculate canvas translation & scale
-		const scale = 1 / (this._z * 50 * this._devicePixelRatio) + 0.01;
+		// Match the Canvas2D viewport transform, where zoom is measured in CSS
+		// pixels per board pixel. The WebGL canvas uses drawing-buffer pixels, so
+		// account for both the viewport and board dimensions on each axis.
+		const pixelsPerBoardPixel = this._z * 50 * this._devicePixelRatio;
+		const scaleX = this.canvas.width / (this._boardWidth * pixelsPerBoardPixel);
+		const scaleY = this.canvas.height / (this._boardHeight * pixelsPerBoardPixel);
 		const ndcX = -(this._x - this._boardWidth / 2) / (this._boardWidth / 2);
 		const ndcY = (this._y - this._boardHeight / 2) / (this._boardHeight / 2);
 
@@ -562,10 +566,9 @@ export class BoardRenderer extends EventTarget {
 		mat4.translate(view, view, [ndcX, ndcY, 0]);
 
 		// Set up projection matrix (zooming)
-		const aspect = this.canvas.width / this.canvas.height;
 		mat4.ortho(projection,
-			-aspect * scale, aspect * scale, // Left right
-			-scale, scale, // Bottom top
+			-scaleX, scaleX, // Left right
+			-scaleY, scaleY, // Bottom top
 			-1, 1 // Clipping plane
 		);
 
@@ -795,7 +798,7 @@ export class BoardRenderer extends EventTarget {
 	 * @param {number} screenY 
 	 * @returns 
 	 */
-	#screenToGameCoords(screenX, screenY) {
+	_screenToGameCoords(screenX, screenY) {
 		// Ensure matrices are up to date
 		this._updateMatrices();
 		
@@ -842,8 +845,8 @@ export class BoardRenderer extends EventTarget {
 		const ndcX = clipPoint[0] / clipPoint[3];
 		const ndcY = clipPoint[1] / clipPoint[3];
 
-		const screenX = (ndcX + 1) / 2 * (this.canvas.width) * this._devicePixelRatio;
-		const screenY = (1 - ndcY) / 2 * (this.canvas.height) * this._devicePixelRatio;
+		const screenX = (ndcX + 1) / 2 * (this.canvas.width / this._devicePixelRatio);
+		const screenY = (1 - ndcY) / 2 * (this.canvas.height / this._devicePixelRatio);
 
 		return {
 			x: screenX,
@@ -859,10 +862,10 @@ export class BoardRenderer extends EventTarget {
 	hitTest(clientX, clientY) {
 		const gl = this._gl;
 		const rect = this.canvas.getBoundingClientRect();
-		const mouseX = Math.floor((clientX - rect.left) * (gl.drawingBufferWidth / rect.width));
-		const mouseY = Math.floor((clientY - rect.top) * (gl.drawingBufferHeight / rect.height));
+		const mouseX = (clientX - rect.left) * (gl.drawingBufferWidth / rect.width);
+		const mouseY = (clientY - rect.top) * (gl.drawingBufferHeight / rect.height);
 
-		const { x: modelX, y: modelY } = this.#screenToGameCoords(mouseX, mouseY);
+		const { x: modelX, y: modelY } = this._screenToGameCoords(mouseX, mouseY);
 		return {
 			x: (modelX + 1) / 2 * this._boardWidth,
 			y: (2 - (modelY + 1)) / 2 * this._boardHeight

--- a/src/pages/index/board-renderer.test.js
+++ b/src/pages/index/board-renderer.test.js
@@ -1,0 +1,143 @@
+import { describe, expect, test } from "bun:test";
+import { mat4 } from "gl-matrix";
+import { BoardRenderer } from "./board-renderer.js";
+
+function createRenderer({
+	boardWidth,
+	boardHeight,
+	cssWidth,
+	cssHeight,
+	devicePixelRatio,
+	x,
+	y,
+	z,
+	left = 0,
+	top = 0
+}) {
+	const drawingBufferWidth = cssWidth * devicePixelRatio;
+	const drawingBufferHeight = cssHeight * devicePixelRatio;
+	const renderer = Object.create(BoardRenderer.prototype);
+
+	renderer.canvas = {
+		width: drawingBufferWidth,
+		height: drawingBufferHeight,
+		getBoundingClientRect() {
+			return {
+				left,
+				top,
+				right: left + cssWidth,
+				bottom: top + cssHeight,
+				width: cssWidth,
+				height: cssHeight
+			};
+		}
+	};
+	renderer._gl = { drawingBufferWidth, drawingBufferHeight };
+	renderer._devicePixelRatio = devicePixelRatio;
+	renderer._boardWidth = boardWidth;
+	renderer._boardHeight = boardHeight;
+	renderer._x = x;
+	renderer._y = y;
+	renderer._z = z;
+	renderer._modelMatrix = mat4.create();
+	renderer._viewMatrix = mat4.create();
+	renderer._projectionMatrix = mat4.create();
+	renderer._mvpMatrix = mat4.create();
+
+	return renderer;
+}
+
+function legacyCanvasPosition(renderer, boardX, boardY) {
+	const scale = renderer._z * 50;
+	return {
+		x: renderer.canvas.width / renderer._devicePixelRatio / 2
+			+ (boardX - renderer._x) * scale,
+		y: renderer.canvas.height / renderer._devicePixelRatio / 2
+			+ (boardY - renderer._y) * scale
+	};
+}
+
+function expectPointClose(actual, expected) {
+	expect(actual.x).toBeCloseTo(expected.x, 3);
+	expect(actual.y).toBeCloseTo(expected.y, 3);
+}
+
+describe("BoardRenderer 2D projection", () => {
+	test("matches the legacy canvas transform on a square board at high DPI", () => {
+		const renderer = createRenderer({
+			boardWidth: 1000,
+			boardHeight: 1000,
+			cssWidth: 1200,
+			cssHeight: 800,
+			devicePixelRatio: 2,
+			x: 412.5,
+			y: 376.5,
+			z: 0.02,
+			left: 17,
+			top: 29
+		});
+
+		for (const [boardX, boardY] of [
+			[renderer._x, renderer._y],
+			[0, 0],
+			[432.75, 346.25],
+			[1000, 1000]
+		]) {
+			const expected = legacyCanvasPosition(renderer, boardX, boardY);
+			expectPointClose(renderer.boardToCanvasElementCoords(boardX, boardY), expected);
+
+			const picked = renderer.hitTest(expected.x + 17, expected.y + 29);
+			expectPointClose(picked, { x: boardX, y: boardY });
+		}
+	});
+
+	test("preserves independent pixel scale on a non-square board and viewport", () => {
+		const renderer = createRenderer({
+			boardWidth: 1600,
+			boardHeight: 600,
+			cssWidth: 900,
+			cssHeight: 700,
+			devicePixelRatio: 1.25,
+			x: 700.5,
+			y: 250.5,
+			z: 0.04
+		});
+
+		for (const [boardX, boardY] of [
+			[renderer._x, renderer._y],
+			[725.25, 270.75],
+			[640.125, 190.875]
+		]) {
+			const expected = legacyCanvasPosition(renderer, boardX, boardY);
+			expectPointClose(renderer.boardToCanvasElementCoords(boardX, boardY), expected);
+			expectPointClose(renderer.hitTest(expected.x, expected.y), {
+				x: boardX,
+				y: boardY
+			});
+		}
+	});
+
+	test("aligns the HTML pixel cursor with the selected board pixel", () => {
+		const renderer = createRenderer({
+			boardWidth: 1000,
+			boardHeight: 1000,
+			cssWidth: 1366,
+			cssHeight: 768,
+			devicePixelRatio: 1,
+			x: 503.7,
+			y: 401.2,
+			z: 0.4
+		});
+		const selectedPixel = {
+			x: Math.floor(renderer._x),
+			y: Math.floor(renderer._y)
+		};
+		const expected = legacyCanvasPosition(renderer, selectedPixel.x, selectedPixel.y);
+
+		expectPointClose(
+			renderer.boardToCanvasElementCoords(selectedPixel.x, selectedPixel.y),
+			expected
+		);
+		expectPointClose(renderer.hitTest(expected.x, expected.y), selectedPixel);
+	});
+});


### PR DESCRIPTION
## Summary

- make the flat WebGL renderer use the same CSS-pixel camera transform as the legacy Canvas2D renderer
- derive independent horizontal and vertical projection scales from the viewport, board dimensions, zoom and device-pixel ratio
- return board overlay positions in CSS pixels instead of multiplying an already scaled drawing buffer by DPR
- preserve fractional pointer coordinates through inverse projection to remove zoom-dependent top-left picking bias
- add focused projection, cursor-alignment and picking regressions for square and non-square boards

## Root cause

The Canvas2D renderer defines zoom as CSS pixels per board pixel. The WebGL projection applied that value directly to normalized model coordinates, implicitly assuming the viewport and board had matching dimensions. It also added a fixed projection offset and mixed device-pixel ratio into camera zoom. As a result, the rendered board used a different scale from the HTML overlays and rectangular boards could not preserve one screen scale on both axes.

Selection overlay conversion separately multiplied by DPR even though the WebGL drawing buffer already included DPR, and pointer picking floored drawing-buffer coordinates before inverse projection.

## Impact

The WebGL board, HTML pixel cursor, placement coordinates and advanced selection handles now share the legacy Canvas2D coordinate model. The 3D and spherical renderer projections are unchanged.

## Validation

- `bun test` — 33 passed
- `bun run build` — passed
- `git diff --check` — passed
- rendered the existing WebGL board test page and confirmed the expected 500 CSS-pixel board extent with no WebGL console errors

The production build retains the existing `shared-ipc` browser-externalisation and stale Browserslist-data warnings.
