### PR TITLE
feat: default to WebGL board with legacy Canvas2D toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -634,8 +634,8 @@
 					<hr>
 					<h3>Experimental settings:</h3>
 					<label>
-						<span>Enable WebGL Canvas:</span>
-						<input type="checkbox" id="enableWebglCanvasCheckbox" style="height: min-content;">
+						<span>Use legacy Canvas2D board:</span>
+						<input type="checkbox" id="useLegacyCanvas2DCheckbox" style="height: min-content;">
 					</label>
 					<label>
 						<span>Enable new overlay menu:</span>

--- a/src/pages/index/secret-settings.js
+++ b/src/pages/index/secret-settings.js
@@ -2,7 +2,7 @@ import { $ } from "../../shared.js";
 import { EditList } from "../../shared-elements.js";
 import { setSelectColourSample, getDefaultSample } from "./game-audio.js";
 
-export let enableWebglCanvas = localStorage.enableWebglCanvas === "true";
+export let useLegacyCanvas2D = localStorage.useLegacyCanvas2D === "true";
 export let enableNewOverlayMenu = localStorage.enableNewOverlayMenu === "true";
 export let enableMelodicPalette = localStorage.enableMelodicPalette === "true";
 
@@ -13,11 +13,11 @@ closeButton.addEventListener("click", function() {
 })
 
 // Experimental settings
-const enableWebglCanvasCheckbox = /**@type {HTMLInputElement}*/($("#enableWebglCanvasCheckbox"));
-enableWebglCanvasCheckbox.checked = enableWebglCanvas;
-enableWebglCanvasCheckbox.addEventListener("change", function() {
-	enableWebglCanvas = !enableWebglCanvas;
-	localStorage.enableWebglCanvas = String(enableWebglCanvas);
+const useLegacyCanvas2DCheckbox = /**@type {HTMLInputElement}*/($("#useLegacyCanvas2DCheckbox"));
+useLegacyCanvas2DCheckbox.checked = useLegacyCanvas2D;
+useLegacyCanvas2DCheckbox.addEventListener("change", function() {
+	useLegacyCanvas2D = !useLegacyCanvas2D;
+	localStorage.useLegacyCanvas2D = String(useLegacyCanvas2D);
 });
 
 const enableNewOverlayMenuCheckbox = /**@type {HTMLInputElement}*/($("#enableNewOverlayMenuCheckbox"));

--- a/src/pages/index/viewport.js
+++ b/src/pages/index/viewport.js
@@ -2,7 +2,7 @@
 import { $, lerp, hash } from "../../shared.js";
 import { CHAT_COLOURS, VIEWPORT_MODE } from "../../defaults.js";
 import { BoardRenderer } from "./board-renderer.js";
-import { enableWebglCanvas } from "./secret-settings.js";
+import { useLegacyCanvas2D } from "./secret-settings.js";
 import { runAudio } from "./game-audio.js";
 import { AUDIOS } from "./game-defaults.js";
 import { connectStatus, cooldownEndDate, HEIGHT, intIdNames, intIdPositions, sendServerMessage, WIDTH } from "./game-state.js";
@@ -27,11 +27,10 @@ const idPositionPlacer = /**@type {HTMLElement}*/($("#idPositionPlacer"));
 /**@type {BoardRenderer|null}*/ export let boardRenderer = null;
 /**@type {CanvasRenderingContext2D|null}*/export let canvasCtx = canvas.getContext("2d");
 
-// Initialise
-if (enableWebglCanvas) {
+if (!useLegacyCanvas2D) {
 	try {
 		boardRenderer = new BoardRenderer(viewportCanvas);
-		canvas.style.opacity = "0";			
+		canvas.style.opacity = "0";
 	}
 	catch (e) {
 		console.error(e);


### PR DESCRIPTION
Swap the experimental "Enable WebGL Canvas" secret setting for a "Use legacy Canvas2D board" setting with inverted logic. WebGL2 is now the default board renderer; the legacy Canvas2D board is used when the user opts in via secret settings, or automatically when WebGL2 is unavailable (the existing try/catch around BoardRenderer construction already falls back to the legacy canvas).