### PR TITLE
feat: add i18n hooks for game page UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,9 +90,9 @@
 				</div>
 				<div id="placeContext" class="context-menu" style="display: none;">
 					<menu>
-						<li><button type="button" id="placeContextReportButton" disabled>Report here</button></li>
-						<li><button type="button" id="placeContextInfoButton">Show pixel placer info</button></li>
-						<li id="placeContextModItem"><button type="button" id="placeContextModButton" disabled>Moderate here</button></li>
+						<li><button type="button" id="placeContextReportButton" disabled translate="reportHere">Report here</button></li>
+						<li><button type="button" id="placeContextInfoButton" translate="showPixelPlacerInfo">Show pixel placer info</button></li>
+						<li id="placeContextModItem"><button type="button" id="placeContextModButton" disabled translate="moderateHere">Moderate here</button></li>
 					</menu>
 				</div>
 				<div id="placeChatMessages">
@@ -108,9 +108,9 @@
 			</div>
 
 			<!-- Game layout/HUD Elements -->
-			<button type="button" noselect id="closebtn" class="layout" title="More">...</button>
+			<button type="button" noselect id="closebtn" class="layout" title="More" translate-title="more">...</button>
 			<r-position-indicator id="positionIndicator" class="layout"></r-position-indicator>
-			<button type="button" noselect id="helpbtn" class="layout" title="Help">
+			<button type="button" noselect id="helpbtn" class="layout" title="Help" translate-title="help">
 				<img class="icon-image" alt="?" src="/svg/help.svg">
 			</button>
 			<button type="button" id="place" class="layout" translate="connecting" noselect>Connecting...</button>
@@ -128,8 +128,8 @@
 					<h4 id="nicknameSubheading" style="color: lightgrey;" translate="pleaseBeRespectful">Please be respectful and try not to spam!</h4>
 					<br>
 					<div class="name-input-container">
-						<input id="nameInput" type="text" placeholder="Enter nickname..." maxlength="16"> <!--TODO: translate="enterNickname"-->
-						<button id="nameButton" type="button" title="Confirm name">
+						<input id="nameInput" type="text" placeholder="Enter nickname..." maxlength="16" translate="enterNickname">
+						<button id="nameButton" type="button" title="Confirm name" translate-title="confirmName">
 							<img alt="✔️" src="/svg/green-checkmark.svg">
 						</button>
 					</div>
@@ -139,7 +139,7 @@
 					<h2 style="white-space:nowrap" translate="liveChat" class="live-chat-header1">Live Chat:</h2>
 					<div class="channels-options">
 						<span id="channelDropParent" style="opacity: 1;">
-							<button type="button" id="channelButton" title="Change channel" class="channel-button">
+							<button type="button" id="channelButton" title="Change channel" translate-title="changeChannel" class="channel-button">
 								<svg class="icon-image" style="vertical-align: bottom;" xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 -960 960 960" width="24">
 									<path d="M480-345 240-585l43-43 197 198 197-197 43 43-240 239Z"/>
 								</svg>	
@@ -188,16 +188,16 @@
 					<button type="button" id="chatAdCloseButton" class="chat-ad-close">x</button>
 				</a>
 				<span id="adLabel" style="display: none; opacity: 0; align-self: center;" translate="adHidden">Ad hidden for 14 days!</span>
-				<button type="button" id="chatPreviousButton" class="horizontal-labeled-separator" noselect><hr><span>See previous messages</span><hr></button>
+				<button type="button" id="chatPreviousButton" class="horizontal-labeled-separator" noselect><hr><span translate="seePreviousMessages">See previous messages</span><hr></button>
 				<div id="chatMessages" class="chat-message-list"><!--Live chat messages--></div>
 				<div id="messageTypePanel" class="chat-input-panel" closed>
-					<input type="button" class="messageTypeBtn" title="Use the shortcut 'ctrl+enter' to send quickly" style="left: 5px;" translate="putOnCanvas" value="🫧 Put on canvas">
-					<input type="button" class="messageTypeBtn" title="Use the shortcut 'enter' to send quickly" style="right: 5px;" translate="sendInLiveChat" value="📨 Send in live chat">
+					<input type="button" class="messageTypeBtn" title="Use the shortcut 'ctrl+enter' to send quickly" translate-title="sendQuicklyCtrlEnter" style="left: 5px;" translate="putOnCanvas" value="🫧 Put on canvas">
+					<input type="button" class="messageTypeBtn" title="Use the shortcut 'enter' to send quickly" translate-title="sendQuicklyEnter" style="right: 5px;" translate="sendInLiveChat" value="📨 Send in live chat">
 				</div>
 				<div id="messageEmojisPanel" class="chat-input-panel" closed><!--Message emoji suggestions--></div>
 				<div id="messageReplyPanel" class="chat-input-panel" closed>
-					<div id="messageReplyLabel">Replying to:</div>
-					<button type="button" id="messageCancelReplyButton" title="Cancel reply">
+					<div id="messageReplyLabel" translate="replyTo">Replying to:</div>
+					<button type="button" id="messageCancelReplyButton" title="Cancel reply" translate-title="cancelReply">
 						<svg class="icon-image" xmlns="http://www.w3.org/2000/svg" viewBox="0 -960 960 960" height="24" width="32">
 							<path d="m330-288 150-150 150 150 42-42-150-150 150-150-42-42-150 150-150-150-42 42 150 150-150 150 42 42ZM480-80q-82 0-155-31.5t-127.5-86Q143-252 111.5-325T80-480q0-83 31.5-156t86-127Q252-817 325-848.5T480-880q83 0 156 31.5T763-763q54 54 85.5 127T880-480q0 82-31.5 155T763-197.5q-54 54.5-127 86T480-80Zm0-60q142 0 241-99.5T820-480q0-142-99-241t-241-99q-141 0-240.5 99T140-480q0 141 99.5 240.5T480-140Zm0-340Z"></path>
 						</svg>
@@ -209,11 +209,11 @@
 						<r-gif-panel id="messageInputGifPanel" class="chat-bottom-panel"></r-gif-panel>
 						<textarea id="messageInput" type="text" placeholder="Enter message..." translate="enterMessage" enterkeyhint="send" maxlength="200"></textarea>
 						<div class="message-input-actions">
-							<button type="button" id="messageAddEmojiButton" title="Add emoji">
+							<button type="button" id="messageAddEmojiButton" title="Add emoji" translate-title="addEmoji">
 								<img alt="Add emoji" width="24" height="24" src="/svg/emoji.svg" class="icon-image">
 							</button>
-							<button type="button" id="messageAddGifButton" title="Add gif">
-								<img alt="Add emoji" width="24" height="24" src="/svg/gif.svg" class="icon-image">
+							<button type="button" id="messageAddGifButton" title="Add gif" translate-title="addGif">
+								<img alt="Add gif" width="24" height="24" src="/svg/gif.svg" class="icon-image">
 							</button>
 						</div>
 					</div>
@@ -224,33 +224,33 @@
 			<!-- Popups and dialogs -->
 			<div id="advancedViewMenu" class="toast-menu">
 				<div class="menu-header">
-					<h2>Advanced view options:</h2>
+					<h2 translate="advancedViewOptions">Advanced view options:</h2>
 					<r-close-icon id="avmCloseButton" class="active"></r-close-icon>
 				</div>
 				<div class="menu-body">
-					<h3>Selection mode:</h3>
+					<h3 translate="selectionMode">Selection mode:</h3>
 					<r-selections-display id="avmSelectionsDisplay"></r-selections-display>
-					<button type="button" id="avmCreateSelectionButton">+ Create a selection</button>
-					<h3>Render layers:</h3>
-					<p>
+					<button type="button" id="avmCreateSelectionButton" translate="createSelection">+ Create a selection</button>
+					<h3 translate="renderLayers">Render layers:</h3>
+					<p translate="renderLayersDescription">
 						Control what board layers are being rendered by the game:
 					</p>
 					<ul class="avm-view-layers noselect">
 						<li>
 							<label>
-								Canvas layer:
+								<span translate="canvasLayer">Canvas layer:</span>
 								<input type="checkbox" id="viewCanvasLayer" checked="true">
 							</label>
 						</li>
 						<li>
 							<label>
-								Changes layer:
+								<span translate="changesLayer">Changes layer:</span>
 								<input type="checkbox" id="viewChangesLayer" checked="true">
 							</label>
 						</li>
 						<li>
 							<label>
-								Pixels layer:
+								<span translate="pixelsLayer">Pixels layer:</span>
 								<input type="checkbox" id="viewSocketPixelsLayer" checked="true">
 							</label>
 						</li>
@@ -259,53 +259,53 @@
 			</div>
 			<div id="spectateMenu" class="toast-menu">
 				<div class="menu-header">
-					<h2>Spectate:</h2>
+					<h2 translate="spectateLabel">Spectate:</h2>
 					<r-close-icon id="spectateCloseButton" class="active"></r-close-icon>
 				</div>
 				<div class="menu-body">
-					<h4>Spectate user:</h4>
+					<h4 translate="spectateUser">Spectate user:</h4>
 					<label>
-						User ID:
-						<input id="spectateUserIdInput" type="number" placeholder="Enter User ID">
+						<span translate="userIdLabel">User ID:</span>
+						<input id="spectateUserIdInput" type="number" placeholder="Enter User ID" translate="enterUserId">
 					</label>
 					<p id="spectateStatusLabel"></p>
 				</div>
 			</div>
 			<div id="overlayMenuOld" noselect class="toast-menu">
 				<div class="menu-header">
-					<h2 title="Make use of a canvas overlay image in order to help yourself better position your pixels" style="display: inline;flex-grow: 1;">Overlay:</h2>
+					<h2 title="Make use of a canvas overlay image in order to help yourself better position your pixels" translate="overlayLabel" translate-title="overlayTooltip" style="display: inline;flex-grow: 1;">Overlay:</h2>
 					<r-close-icon id="overlayMenuOldCloseButton" class="active"></r-close-icon>
 				</div>
 				<div class="menu-body">
 					<input id="overlayInput" type="file" style="width: 100%;">
 					<label>
-						Image X:
-						<input value="" id="overlayXInput" type="number" placeholder="Enter Image X" style="width: calc(50% - 5px); margin-right: 5px;"/>
+						<span translate="imageX">Image X:</span>
+						<input value="" id="overlayXInput" type="number" placeholder="Enter Image X" translate="enterImageX" style="width: calc(50% - 5px); margin-right: 5px;"/>
 					</label>
 					<label>
-						Image Y:
-						<input value="" id="overlayYInput" type="number" placeholder="Enter Image Y" style="width: calc(50% - 5px)"/>
+						<span translate="imageY">Image Y:</span>
+						<input value="" id="overlayYInput" type="number" placeholder="Enter Image Y" translate="enterImageY" style="width: calc(50% - 5px)"/>
 					</label>
-					<label>
+					<label translate="imageOpacity">
 						Image Opacity:
 					</label>
 					<div class="labelled-slider">
 						<input id="overlayOpacity" type="range" class="slider" min="0" value="80" max="100">
-						<label for="overlayOpacity" class="slider-label">Adjust opacity</label>
+						<label for="overlayOpacity" class="slider-label" translate="adjustOpacity">Adjust opacity</label>
 						<div class="slider-track">
 						<div id="overlaySliderValue" class="slider-value" data-value="80" style="--value: 80%;"></div>
 						</div>
 					</div>
-					<div id="overlayCopyButton" style="position: relative; display: flex;" title="Copy canvas link">
+					<div id="overlayCopyButton" style="position: relative; display: flex;" title="Copy canvas link" translate-title="copyCanvasLink">
 						<img class="icon-image" src="/svg/clipboard.svg" alt="Clipboard">
-						<span style="align-self: center; margin-right: 8px;cursor: pointer;">Copy overlay URL</span>
-						<span style="opacity: 0; align-self: center;">Copied to clipboard!</span>
+						<span style="align-self: center; margin-right: 8px;cursor: pointer;" translate="copyOverlayUrl">Copy overlay URL</span>
+						<span style="opacity: 0; align-self: center;" translate="copiedToClipboard">Copied to clipboard!</span>
 					</div>
 				</div>
 			</div>
 			<dialog id="overlayMenu" class="dialog-modal" noselect>
 				<div style="display: flex;">
-					<h2 title="Make use of a canvas overlay image in order to help yourself better position your pixels" style="display: inline;flex-grow: 1;">Overlay:</h2>
+					<h2 title="Make use of a canvas overlay image in order to help yourself better position your pixels" translate="overlayLabel" translate-title="overlayTooltip" style="display: inline;flex-grow: 1;">Overlay:</h2>
 					<r-close-icon id="overlayMenuCloseButton" class="active"></r-close-icon>
 				</div>
 				<div id="overlayMenuInnerBox" class="modal-inner-container" style="flex-grow: 3;">
@@ -318,74 +318,74 @@
 				</div>
 				<div style="flex-grow: 1; display: flex; column-gap: 16px;">
 					<div style="flex-grow: 1; display: flex; flex-direction: column; row-gap: 8px;">
-						<h2>Select image:</h2>
+						<h2 translate="selectImage">Select image:</h2>
 						<input id="overlayInput" type="file" style="width: fit-content;">
-						<h2>Share</h2>
-						<div style="position: relative; display: flex;" title="copy canvas link">
+						<h2 translate="share">Share</h2>
+						<div style="position: relative; display: flex;" title="copy canvas link" translate-title="copyCanvasLink">
 							<img class="icon-image" src="svg/clipboard.svg">
-							<span style="align-self: center; margin-right: 8px;cursor: pointer;">Copy overlay URL</span>
-							<span style="opacity: 0; align-self: center;">Copied to clipboard!</span>
+							<span style="align-self: center; margin-right: 8px;cursor: pointer;" translate="copyOverlayUrl">Copy overlay URL</span>
+							<span style="opacity: 0; align-self: center;" translate="copiedToClipboard">Copied to clipboard!</span>
 						</div>
 					</div>
 					<hr>
 					<div style="flex-grow: 1; display: flex; flex-direction: column; row-gap: 8px;">
-						<h2>Adjust image</h2>
-						<h4>Colour matching:</h4>
+						<h2 translate="adjustImage">Adjust image</h2>
+						<h4 translate="colourMatching">Colour matching:</h4>
 						<div>
 							<input type="radio" name="overlayMatch" id="overlayMatchNearest">
-							<label for="overlayMatchNearest">Nearest match</label>
+							<label for="overlayMatchNearest" translate="nearestMatch">Nearest match</label>
 						</div>
 						<div>
 							<input type="radio" name="overlayMatch" id="overlayMatchIgnore">
-							<label for="overlayMatchIgnore">Ignore invalid colours</label>
+							<label for="overlayMatchIgnore" translate="ignoreInvalidColours">Ignore invalid colours</label>
 						</div>
-						<h4>Image options:</h4>
+						<h4 translate="imageOptions">Image options:</h4>
 						<div>
 							<input type="checkbox" id="overlaySharpen">
-							<label for="overlaySharpen">Sharpen image edges</label>
+							<label for="overlaySharpen" translate="sharpenImageEdges">Sharpen image edges</label>
 						</div>
 						<div>
 							<input type="checkbox" id="overlayFlipX">
-							<label for="overlayFlipX">Flip image X</label>
+							<label for="overlayFlipX" translate="flipImageX">Flip image X</label>
 						</div>
 						<div>
 							<input type="checkbox" id="overlayFlipY">
-							<label for="overlayFlipY">Flip image Y</label>
+							<label for="overlayFlipY" translate="flipImageY">Flip image Y</label>
 						</div>
 					</div>
 				</div>
 			</dialog>
 			<div id="turnstileMenu" class="toast-menu noselect">
 				<div class="menu-header">
-					<h2>Verifying session...</h2>
+					<h2 translate="verifyingSession">Verifying session...</h2>
 				</div>
 				<div class="menu-body">
-					<p>Don't worry, this process should be automatic!</p><br>
+					<p translate="turnstileAutomatic">Don't worry, this process should be automatic!</p><br>
 					<div id="turnstileContainer"></div>
 				</div>
 			</div>
 			<div id="hCaptchaMenu" class="toast-menu noselect">
 				<div class="menu-header">
-					<h2>Complete captcha</h2>
+					<h2 translate="completeCaptcha">Complete captcha</h2>
 				</div>
 				<div class="menu-body">
-					<p>Please complete the below captcha to continue playing the game!</p><br>
+					<p translate="hcaptchaPrompt">Please complete the below captcha to continue playing the game!</p><br>
 					<div id="hCaptchaContainer"></div>
-					<button type="button" id="hCaptchaSubmitButton">Continue</button>
+					<button type="button" id="hCaptchaSubmitButton" translate="continue">Continue</button>
 				</div>
 			</div>
 			<div id="passkeyMenu" class="toast-menu noselect">
 				<div class="menu-header">
-					<h2 id="passkeyMenuTitle">Passkey required</h2>
+					<h2 id="passkeyMenuTitle" translate="passkeyRequired">Passkey required</h2>
 				</div>
 				<div class="menu-body">
-					<p id="passkeyMenuMessage">Use a passkey to place pixels and send chat messages.</p><br>
-					<button type="button" id="passkeyMenuButton">Continue</button>
+					<p id="passkeyMenuMessage" translate="passkeyRequiredMessage">Use a passkey to place pixels and send chat messages.</p><br>
+					<button type="button" id="passkeyMenuButton" translate="continue">Continue</button>
 				</div>
 			</div>
 			<div id="punishmentMenu" class="toast-menu">
 				<div class="menu-header">
-					<h2>Punishment notice:</h2>
+					<h2 translate="punishmentNotice">Punishment notice:</h2>
 				</div>
 				<div class="menu-body">
 					<p id="punishmentNote"></p>
@@ -401,12 +401,12 @@
 							<p id="punishmentAppeal"></p>
 							<div id="punishmentAppealConversation" class="chat-message-list appeal-conversation" hidden></div>
 							<form id="punishmentAppealForm" class="punishment-appeal-form" hidden>
-								<label for="punishmentAppealMessage">Appeal</label>
+								<label for="punishmentAppealMessage" translate="appeal">Appeal</label>
 								<textarea id="punishmentAppealMessage" maxlength="1000" required
-									placeholder="Explain why this punishment should be reviewed"></textarea>
+									placeholder="Explain why this punishment should be reviewed" translate="appealPlaceholder"></textarea>
 								<div class="punishment-appeal-submit-row">
 									<small id="punishmentAppealLimit">0 / 1000 bytes</small>
-									<button id="punishmentAppealSubmitButton" type="submit" disabled>Submit appeal</button>
+									<button id="punishmentAppealSubmitButton" type="submit" disabled translate="submitAppeal">Submit appeal</button>
 								</div>
 							</form>
 						</div>
@@ -415,91 +415,92 @@
 			</div>
 			<div id="moderationMenu" noselect="" mode="delete" class="toast-menu">
 				<div class="menu-header">
-					<h2 style="display: inline;flex-grow: 1;">Moderation options:</h2>
+					<h2 style="display: inline;flex-grow: 1;" translate="moderationOptions">Moderation options:</h2>
 					<r-close-icon id="modCloseButton"></r-close-icon>
 				</div>
 				<div class="menu-body">
-					<h2>Manage:</h2>
+					<h2 translate="manage">Manage:</h2>
 					<div id="modMessageIdForm" class="mod-form">
 						<label>
-							<span>Message ID:</span>
-							<input type="number" id="modMessageId" title="Message ID" placeholder="Enter Message ID">
+							<span translate="messageIdLabel">Message ID:</span>
+							<input type="number" id="modMessageId" title="Message ID" placeholder="Enter Message ID" translate="enterMessageId" translate-title="enterMessageId">
 						</label>
-						<div id="modMessagePreview">Message not found</div>
+						<div id="modMessagePreview" translate="messageNotFound">Message not found</div>
 					</div>
 					<label id="modUserIdForm">
-						User ID:
-						<input type="number" id="modUserId" title="User ID" placeholder="Enter User ID">
+						<span translate="userIdLabel">User ID:</span>
+						<input type="number" id="modUserId" title="User ID" placeholder="Enter User ID" translate="enterUserId" translate-title="enterUserId">
 					</label>
-					<h2>Action:</h2>
+					<h2 translate="actionLabel">Action:</h2>
 					<form id="modActionForm" class="mod-form">
 						<label>
-							<span>Delete message</span>
+							<span translate="deleteMessage">Delete message</span>
 							<input type="radio" id="modActionDelete" name="modAction" value="delete">
 						</label>
 						<label>
-							<span>Kick</span>
+							<span translate="kick">Kick</span>
 							<input type="radio" id="modActionKick" name="modAction" value="kick">
 						</label>
 						<label>
-							<span>Mute</span>
+							<span translate="mute">Mute</span>
 							<input type="radio" id="modActionMute" name="modAction" value="mute">
 						</label>
 						<label>
-							<span>Ban</span>
+							<span translate="ban">Ban</span>
 							<input type="radio" id="modActionBan" name="modAction" value="ban">
 						</label>
 						<label>
-							<span>Captcha</span>
+							<span translate="captcha">Captcha</span>
 							<input type="radio" id="modActionCaptcha" name="modAction" value="captcha">
 						</label>
 					</form>
 					<div id="modDuration">
-						<input id="modDurationH" type="number" style="display: inline;height: auto;width: 80px;" placeholder="Hours" min="0">
+						<input id="modDurationH" type="number" style="display: inline;height: auto;width: 80px;" placeholder="Hours" min="0" translate="hours">
 						<span>:</span>
-						<input id="modDurationM" type="number" style="display: inline;height: auto;width: 80px;" placeholder="Minutes" min="0">
+						<input id="modDurationM" type="number" style="display: inline;height: auto;width: 80px;" placeholder="Minutes" min="0" translate="minutes">
 						<span>:</span>
-						<input id="modDurationS" type="number" style="display: inline;height: auto;width: 80px;" placeholder="Seconds" min="1">
+						<input id="modDurationS" type="number" style="display: inline;height: auto;width: 80px;" placeholder="Seconds" min="1" translate="seconds">
 					</div>
 					<div id="modAffectsAllForm" class="mod-form">
 						<div>
 							<input type="checkbox" id="modAffectsAll" style="height: auto; width: 12px;" value="affectsall" />
-							<label for="modAffectsAll">Apply to all players</label>
+							<label for="modAffectsAll" translate="applyToAllPlayers">Apply to all players</label>
 						</div>
 					</div>
-					<em>All moderation actions are logged by the server and reports sent to all other staff. Follow the moderation rules. Do not abuse power.</em>
-					<input id="modReason" type="text" placeholder="Reason">
+					<em translate="moderationWarning">All moderation actions are logged by the server and reports sent to all other staff. Follow the moderation rules. Do not abuse power.</em>
+					<input id="modReason" type="text" placeholder="Reason" translate="reason">
+					<button type="button" id="modReviewButton" style="width: 100%;" translate="punishmentReview">Punishment review</button>
 					<div style="display: flex; column-gap: 8px;">
-						<button type="button" style="flex-grow: 1;" id="modOptionsButton" disabled="true">Submit</button>
-						<button type="button" id="modCancelButton" style="flex-grow: 1;">Cancel</button>
+						<button type="button" style="flex-grow: 1;" id="modOptionsButton" disabled="true" translate="submit">Submit</button>
+						<button type="button" id="modCancelButton" style="flex-grow: 1;" translate="cancel">Cancel</button>
 					</div>
 				</div>
 			</div>
 			<dialog id="moderationReviewDialog" class="dialog-modal moderation-review-modal" aria-labelledby="moderationReviewTitle">
 				<div class="modal-header moderation-review-header">
 					<div>
-						<h2 id="moderationReviewTitle">Punishment review</h2>
-						<p>Review mute and ban records and respond to appeals.</p>
+						<h2 id="moderationReviewTitle" translate="punishmentReview">Punishment review</h2>
+						<p translate="punishmentReviewDescription">Review mute and ban records and respond to appeals.</p>
 					</div>
 					<r-close-icon id="moderationReviewCloseButton"></r-close-icon>
 				</div>
 				<nav class="tab-bar" role="tablist" aria-label="Punishment type">
-					<button id="moderationMutesTab" type="button" role="tab" aria-selected="true">Mutes</button>
-					<button id="moderationBansTab" type="button" role="tab" aria-selected="false">Bans</button>
+					<button id="moderationMutesTab" type="button" role="tab" aria-selected="true" translate="mutes">Mutes</button>
+					<button id="moderationBansTab" type="button" role="tab" aria-selected="false" translate="bans">Bans</button>
 				</nav>
 				<p id="moderationReviewStatus" role="status"></p>
 				<div id="moderationReviewList" class="moderation-review-list" role="list"></div>
-				<button id="moderationReviewMoreButton" type="button" hidden>Load 50 more</button>
+				<button id="moderationReviewMoreButton" type="button" hidden translate="loadMore">Load 50 more</button>
 			</dialog>
 			<dialog id="captchaPopup" class="modal">
 				<div>
 					<canvas id="captchaCanvas" width="500" height="800"></canvas>
-					<h1 noselect style="color: grey;">🤔 Sorry for interrupting, but</h1>
+					<h1 noselect style="color: grey;" translate="sorryForInterrupting">🤔 Sorry for interrupting, but</h1>
 					<p noselect translate="captchaPrompt"><em>Solve this small captcha to help keep rplace.live fun for all...</em></p>
 					<hr>
-					<h2 id="captchaLabel">Please click the button containing the emoji you see below</h2>
+					<h2 id="captchaLabel" translate="captchaClickEmoji">Please click the button containing the emoji you see below</h2>
 					<div id="captchaImagePosition"><!--captcha canvas image space--></div>
-					<a style="text-align: center;" href=".">(generate new captcha)</a>
+					<a style="text-align: center;" href="." translate="generateNewCaptcha">(generate new captcha)</a>
 					<div id="captchaOptions"><!--clickable captcha answers--></div>
 				</div>
 			</dialog>
@@ -512,22 +513,22 @@
 			</dialog>
 			<dialog id="placerInfoDialog" class="modal placer-info-modal" aria-labelledby="placerInfoTitle">
 				<div class="modal-header">
-					<h2 id="placerInfoTitle">Pixel placer info</h2>
+					<h2 id="placerInfoTitle" translate="placerInfoTitle">Pixel placer info</h2>
 					<r-close-icon id="placerInfoCloseButton"></r-close-icon>
 				</div>
 				<div class="modal-content placer-info-content">
-					<p id="placerInfoStatus" role="status">Looking up placer information...</p>
+					<p id="placerInfoStatus" role="status" translate="lookingUpPlacer">Looking up placer information...</p>
 					<dl id="placerInfoDetails" class="placer-info-details" hidden>
 						<div>
-							<dt>Position</dt>
+							<dt translate="position">Position</dt>
 							<dd id="placerInfoPosition"></dd>
 						</div>
 						<div>
-							<dt>Name</dt>
+							<dt translate="name">Name</dt>
 							<dd id="placerInfoName"></dd>
 						</div>
 						<div>
-							<dt>User ID</dt>
+							<dt translate="userId">User ID</dt>
 							<dd id="placerInfoUserId"></dd>
 						</div>
 					</dl>
@@ -540,16 +541,16 @@
 						<r-close-icon id="canvasReportCloseButton"></r-close-icon>
 					</div>
 					<div class="modal-content canvas-report-content">
-						<p>Report the player who placed the pixel at <strong id="canvasReportPosition"></strong>.</p>
-						<label for="canvasReportReason">Reason</label>
+						<p><span translate="reportPixelAt">Report the player who placed the pixel at </span><strong id="canvasReportPosition"></strong>.</p>
+						<label for="canvasReportReason" translate="reason">Reason</label>
 						<textarea id="canvasReportReason" maxlength="280" required
-							placeholder="Describe what should be reviewed" aria-describedby="canvasReportLimit"></textarea>
+							placeholder="Describe what should be reviewed" translate="canvasReportPlaceholder" aria-describedby="canvasReportLimit"></textarea>
 						<small id="canvasReportLimit">0 / 280 bytes</small>
 						<p id="canvasReportStatus" role="status" hidden></p>
 					</div>
 					<div class="canvas-report-actions">
-						<button id="canvasReportSubmitButton" type="submit" disabled>Submit report</button>
-						<button id="canvasReportCancelButton" type="button">Cancel</button>
+						<button id="canvasReportSubmitButton" type="submit" disabled translate="submitReport">Submit report</button>
+						<button id="canvasReportCancelButton" type="button" translate="cancel">Cancel</button>
 					</div>
 				</form>
 			</dialog>
@@ -564,13 +565,13 @@
 					Individually you can create something.<br><br>
 					Together you can create something more.<br><br>
 				</div>
-				<div class="modal-install" id="modalInstallButton" noselect>Install rplace.live web app</div>
-				<button id="modalCopyrightButton" type="button" title="Open secret settings" class="modal-content copyright-label">
+				<div class="modal-install" id="modalInstallButton" noselect translate="webappInstall">Install rplace.live web app</div>
+				<button id="modalCopyrightButton" type="button" title="Open secret settings" translate-title="openSecretSettings" class="modal-content copyright-label">
 					© Zekiah-A, BlobKat
 				</button>
 				<div class="modal-footer">
 					<img noselect="" alt="Place Logo" height="40" width="40" src="images/rplace.png" style="position: absolute;left: 50%;transform: translateX(-50%);opacity: 0.2;">
-					<button type="button" id="muteButton" noselect class="modal-footer-button" title="Enable sounds">
+					<button type="button" id="muteButton" noselect class="modal-footer-button" title="Enable sounds" translate-title="enableSounds">
 						<image id="muteButtonImage" class="icon-image" src="/svg/muted.svg"></image>
 					</button>
 					<div id="themeDropParent" noselect class="modal-footer-button" style="width: auto; align-items: center;justify-content: center;">
@@ -602,7 +603,7 @@
 							</menu>
 						</div>
 					</div>
-					<button type="button" id="placeChatButton" class="modal-footer-button" title="Enable canvas chat">
+					<button type="button" id="placeChatButton" class="modal-footer-button" title="Enable canvas chat" translate-title="enableCanvasChat">
 						<img id="placeChatButtonImage" src="/svg/place-chat.svg" width="60">
 					</button>
 				</div>
@@ -657,12 +658,12 @@
 					<div id="colours"></div>
 				</div>
 				<div class="buttons">
-					<button type="button" id="pcancel" class="pcancel" title="Cancel">
+					<button type="button" id="pcancel" class="pcancel" title="Cancel" translate-title="cancel">
 						<svg class="icon-image" xmlns="http://www.w3.org/2000/svg" data-name="icons final" viewBox="0 0 20 20">
 							<path d="M18.442 2.442l-.884-.884L10 9.116 2.442 1.558l-.884.884L9.116 10l-7.558 7.558.884.884L10 10.884l7.558 7.558.884-.884L10.884 10l7.558-7.558z"></path>
 						</svg>
 					</button>
-					<button type="button" id="pok" class="pok" title="Confirm place pixel">
+					<button type="button" id="pok" class="pok" title="Confirm place pixel" translate-title="confirmPlacePixel">
 						<svg class="icon-image" xmlns="http://www.w3.org/2000/svg" data-name="icons final" viewBox="0 0 20 20">
 							<path d="M7.5 15.583a.72.72 0 01-.513-.212L1.558 9.942l.884-.884L7.5 14.116 18.058 3.558l.884.884L8.013 15.371a.72.72 0 01-.513.212z"></path>
 						</svg>
@@ -671,7 +672,7 @@
 			</div>
 		</div>
 		<div id="more">
-			<button type="button" id="spaceFiller" title="Back to game"></button>
+			<button type="button" id="spaceFiller" title="Back to game" translate-title="backToGame"></button>
 			<iframe id="postsFrame" title="posts" frameborder="0" scrolling="no"></iframe>
 		</div>
 		<div id="eventCountdown">

--- a/src/pages/index/game-elements.js
+++ b/src/pages/index/game-elements.js
@@ -385,7 +385,7 @@ export class LiveChatMessage extends LitElement {
 				${until(renderActionButton("/svg/reply-action.svg", "replyTo", this.#notifyReplyClick), html`<span>...</span>`)}
 				${until(renderActionButton("/svg/react-action.svg", "addReaction", this.#notifyReact), html`<span>...</span>`)}
 				${until(renderActionButton("/svg/report-action.svg", "report", this.#notifyReportClick), html`<span>...</span>`)}
-				${localStorage.vip?.startsWith("!") ? until(renderActionButton("svg/moderate-action.svg", "Moderation options", this.#notifyModerateClick), html`<span>Loading...</span>`) : null}
+				${localStorage.vip?.startsWith("!") ? until(renderActionButton("svg/moderate-action.svg", "moderationOptionsAction", this.#notifyModerateClick), html`<span>Loading...</span>`) : null}
 			</div>`
 	}
 
@@ -426,10 +426,10 @@ export class LiveChatMessage extends LitElement {
 								</summary>
 								<div class="reaction-body">
 									<hr>
-									<h3>Added by:</h3>
+									<h3>${until(translate("addedBy"), "Added by:")}</h3>
 									<ul class="reactors">
 										${[...reactors].map((reactor) => html`
-											<li class="reactor" title=${"User ID: #" + reactor.intId}>
+											<li class="reactor" title=${until(translate("userIdLabel").then((/**@type {string}*/label) => `${label} #${reactor.intId}`), "User ID: #" + reactor.intId)}>
 												${reactor.chatName ?? "#" + reactor.intId}
 											</li>
 										`)}
@@ -499,7 +499,8 @@ export class PunishmentRecordElement extends LitElement {
 		record: { attribute:false },
 		busy: { type:Boolean, state:true },
 		response: { type:String, state:true },
-		errorMessage: { type:String, state:true }
+		errorMessage: { type:String, state:true },
+		labels: { attribute:false }
 	};
 
 	constructor() {
@@ -509,11 +510,39 @@ export class PunishmentRecordElement extends LitElement {
 		this.busy = false;
 		this.response = "";
 		this.errorMessage = "";
+		/** @type {Record<string, string>} */
+		this.labels = {
+			unknownModerator: "Unknown moderator",
+			unknownPlayer: "Unknown player",
+			unknownDate: "Unknown",
+			expired: "Expired",
+			active: "Active",
+			punishment: "Punishment",
+			user: "User",
+			issuedBy: "Issued by",
+			started: "Started",
+			ends: "Ends",
+			reason: "Reason",
+			appeal: "Appeal",
+			moderatorResponse: "Moderator response",
+			explainDecision: "Explain the decision",
+			approve: "Approve",
+			deny: "Deny",
+			noResponseRecorded: "No response was recorded.",
+			responseTooLong: "Enter a response no longer than 1000 bytes."
+		};
 	}
 
 	connectedCallback() {
 		super.connectedCallback();
 		this.setAttribute("role", "listitem");
+		void this.#translateLabels();
+	}
+
+	async #translateLabels() {
+		const keys = Object.keys(this.labels);
+		const values = await Promise.all(keys.map(key => translate(key)));
+		this.labels = Object.fromEntries(keys.map((key, index) => [key, values[index]]));
 	}
 
 	createRenderRoot() {
@@ -522,19 +551,19 @@ export class PunishmentRecordElement extends LitElement {
 
 	/** @param {string|null} name @param {number|null} intId */
 	#person(name, intId) {
-		if (typeof intId !== "number" || !Number.isInteger(intId) || intId < 0) return "Unknown moderator";
+		if (typeof intId !== "number" || !Number.isInteger(intId) || intId < 0) return this.labels.unknownModerator;
 		return `${name || "anon"} (#${intId})`;
 	}
 
 	/** @param {number|null} value */
 	#date(value) {
 		return typeof value === "number" && Number.isFinite(value)
-			? new Date(value).toLocaleString() : "Unknown";
+			? new Date(value).toLocaleString() : this.labels.unknownDate;
 	}
 
 	#status() {
-		if (!this.record || this.record.finishDate <= Date.now()) return "Expired";
-		return "Active";
+		if (!this.record || this.record.finishDate <= Date.now()) return this.labels.expired;
+		return this.labels.active;
 	}
 
 	/**
@@ -564,7 +593,7 @@ export class PunishmentRecordElement extends LitElement {
 		const response = this.response.trim();
 		const byteLength = new TextEncoder().encode(response).byteLength;
 		if (byteLength === 0 || byteLength > 1000) {
-			this.errorMessage = "Enter a response no longer than 1000 bytes.";
+			this.errorMessage = this.labels.responseTooLong;
 			return;
 		}
 		this.errorMessage = "";
@@ -588,31 +617,31 @@ export class PunishmentRecordElement extends LitElement {
 				<div class="chat-message-list appeal-conversation">
 					${this.#renderAppealMessage("left", this.record.appealMessage,
 						this.record.appealSubmittedAt, this.record.userIntId,
-						this.record.userChatName, "Unknown player")}
+						this.record.userChatName, this.labels.unknownPlayer)}
 					${pending ? null : this.#renderAppealMessage("right",
-						this.record.appealResponse || "No response was recorded.",
+						this.record.appealResponse || this.labels.noResponseRecorded,
 						this.record.appealRespondedAt, this.record.appealResponderIntId,
-						this.record.appealResponderChatName, "Unknown moderator")}
+						this.record.appealResponderChatName, this.labels.unknownModerator)}
 				</div>
 				${pending ? html`
 					<label class="appeal-response-field">
-						<span>Moderator response</span>
+						<span>${this.labels.moderatorResponse}</span>
 						<textarea .value=${this.response} ?disabled=${this.busy}
 							@input=${(/** @type {InputEvent} */e) => {
 								if (e.currentTarget instanceof HTMLTextAreaElement) this.response = e.currentTarget.value;
 								this.errorMessage = "";
 							}}
-							placeholder="Explain the decision" maxlength="1000"></textarea>
+							placeholder=${this.labels.explainDecision} maxlength="1000"></textarea>
 					</label>
 					${this.errorMessage ? html`<p class="appeal-error" role="alert">${this.errorMessage}</p>` : null}
 					<div class="appeal-decision-actions">
 						<button type="button" class="appeal-approve" ?disabled=${this.busy}
-							@click=${() => this.#submit("approved")}>Approve</button>
+							@click=${() => this.#submit("approved")}>${this.labels.approve}</button>
 						<button type="button" class="appeal-deny" ?disabled=${this.busy}
-							@click=${() => this.#submit("denied")}>Deny</button>
+							@click=${() => this.#submit("denied")}>${this.labels.deny}</button>
 					</div>` : html`
 					<p class="appeal-decision appeal-decision-${this.record.appealStatus}">
-						Appeal ${this.record.appealStatus}
+						${this.labels.appeal} ${this.record.appealStatus}
 					</p>`}
 			</section>`;
 	}
@@ -623,16 +652,16 @@ export class PunishmentRecordElement extends LitElement {
 			<div class="punishment-record-summary">
 				<div>
 					<span class="punishment-record-label">${this.record.type}</span>
-					<strong>Punishment #${this.record.punishmentId}</strong>
+					<strong>${this.labels.punishment} #${this.record.punishmentId}</strong>
 					<span class="punishment-record-state ${this.#status().toLowerCase()}">${this.#status()}</span>
 				</div>
 				<dl>
-					<div><dt>User</dt><dd>${this.#person(this.record.userChatName, this.record.userIntId)}</dd></div>
-					<div><dt>Issued by</dt><dd>${this.#person(this.record.moderatorChatName, this.record.moderatorIntId)}</dd></div>
-					<div><dt>Started</dt><dd>${this.#date(this.record.startDate)}</dd></div>
-					<div><dt>Ends</dt><dd>${this.#date(this.record.finishDate)}</dd></div>
+					<div><dt>${this.labels.user}</dt><dd>${this.#person(this.record.userChatName, this.record.userIntId)}</dd></div>
+					<div><dt>${this.labels.issuedBy}</dt><dd>${this.#person(this.record.moderatorChatName, this.record.moderatorIntId)}</dd></div>
+					<div><dt>${this.labels.started}</dt><dd>${this.#date(this.record.startDate)}</dd></div>
+					<div><dt>${this.labels.ends}</dt><dd>${this.#date(this.record.finishDate)}</dd></div>
 				</dl>
-				<div class="punishment-record-reason"><strong>Reason</strong><p>${this.record.reason}</p></div>
+				<div class="punishment-record-reason"><strong>${this.labels.reason}</strong><p>${this.record.reason}</p></div>
 			</div>`;
 	}
 

--- a/src/pages/index/index.js
+++ b/src/pages/index/index.js
@@ -1,5 +1,5 @@
 import { DEFAULT_BOARD, DEFAULT_SERVER, ADS,  COMMANDS, CUSTOM_EMOJIS, DEFAULT_HEIGHT, DEFAULT_PALETTE_KEYS, DEFAULT_THEMES, DEFAULT_WIDTH, EMOJIS, LANG_INFOS, MAX_CHANNEL_MESSAGES, PUNISHMENT_STATE, PLACEMENT_MODE, RENDERER_TYPE } from "../../defaults.js";
-import { lang, translate, translateAll, $, stringToHtml, blobToBase64, base64ToBlob }  from "../../shared.js";
+import { lang, translate, translateAll, $, stringToHtml, blobToBase64, base64ToBlob, toCapitalised }  from "../../shared.js";
 import { showLoadingScreen, hideLoadingScreen } from "./loading-screen.js";
 import { clearCaptchaCanvas, updateImgCaptchaCanvas, updateImgCaptchaCanvasFallback } from "./captcha-canvas.js";
 import { boardRenderer, canvasCtx, zoomIn, moveTo, setPlaceChatPosition, setMinZoom, pos, x, y, z, minZoom, setX, setY, setZ, setViewportRenderer } from "./viewport.js";
@@ -221,7 +221,7 @@ function getHttpServerUrl() {
 		.replace("wss://", "https://").replace("ws://", "http://");
 }
 
-function updatePasskeyMenu(message = "") {
+async function updatePasskeyMenu(message = "") {
 	if (passkeyAuthState === "completed" || passkeyAuthState === "not-required") {
 		passkeyMenu.removeAttribute("open");
 		passkeyAuthBusy = false;
@@ -233,24 +233,24 @@ function updatePasskeyMenu(message = "") {
 	passkeyMenuButton.disabled = passkeyAuthBusy || passkeyAuthState === "unsupported";
 
 	if (passkeyAuthBusy) {
-		passkeyMenuTitle.textContent = "Passkey in progress";
-		passkeyMenuMessage.textContent = "Follow your browser's passkey prompt to continue.";
-		passkeyMenuButton.textContent = "Waiting...";
+		passkeyMenuTitle.textContent = await translate("passkeyInProgress");
+		passkeyMenuMessage.textContent = await translate("passkeyBrowserPrompt");
+		passkeyMenuButton.textContent = await translate("waiting");
 	}
 	else if (passkeyAuthState === "unsupported") {
-		passkeyMenuTitle.textContent = "Passkeys unavailable";
-		passkeyMenuMessage.textContent = message || "This browser or page cannot use passkeys. You can still spectate, but placing and chat are unavailable here.";
-		passkeyMenuButton.textContent = "Unavailable";
+		passkeyMenuTitle.textContent = await translate("passkeysUnavailable");
+		passkeyMenuMessage.textContent = message || await translate("passkeysUnsupportedMessage");
+		passkeyMenuButton.textContent = await translate("unavailable");
 	}
 	else if (passkeyAuthState === "failed") {
-		passkeyMenuTitle.textContent = "Passkey failed";
-		passkeyMenuMessage.textContent = message || "Passkey authentication did not complete. You can try again.";
-		passkeyMenuButton.textContent = "Try again";
+		passkeyMenuTitle.textContent = await translate("passkeyFailed");
+		passkeyMenuMessage.textContent = message || await translate("passkeyFailedMessage");
+		passkeyMenuButton.textContent = await translate("tryAgain");
 	}
 	else {
-		passkeyMenuTitle.textContent = "Passkey required";
-		passkeyMenuMessage.textContent = message || "Use a passkey to place pixels and send chat messages.";
-		passkeyMenuButton.textContent = "Continue";
+		passkeyMenuTitle.textContent = await translate("passkeyRequired");
+		passkeyMenuMessage.textContent = message || await translate("passkeyRequiredMessage");
+		passkeyMenuButton.textContent = await translate("continue");
 	}
 }
 
@@ -279,7 +279,7 @@ async function startPasskeyAuth() {
 	}
 
 	if (!supportsPasskeys()) {
-		setPasskeyAuthState("unsupported", "This browser or page cannot use passkeys. Try a secure browser session on a passkey-capable device.");
+		setPasskeyAuthState("unsupported", await translate("passkeysSecureSessionMessage"));
 		return;
 	}
 
@@ -303,7 +303,7 @@ async function startPasskeyAuth() {
 		await refreshPasskeyStatus();
 	}
 	catch (error) {
-		const message = error instanceof Error ? error.message : "Passkey authentication did not complete.";
+		const message = error instanceof Error ? error.message : await translate("passkeyFailedDefault");
 		setPasskeyAuthState("failed", message);
 	}
 	finally {
@@ -680,12 +680,12 @@ const activePunishmentTypes = new Set();
  * @param {string} message
  * @param {number|null} date
  */
-function appendAppealMessage(container, displaySide, senderIntId, senderChatName, message, date) {
+async function appendAppealMessage(container, displaySide, senderIntId, senderChatName, message, date) {
 	const appealMessage = /** @type {import("./game-elements.js").LiveChatMessage} */(
 		document.createElement("r-live-chat-message"));
 	appealMessage.dataset.displaySide = displaySide;
 	appealMessage.dataset.explicitTime = typeof date === "number" && Number.isFinite(date)
-		? new Date(date).toLocaleString() : "Unknown time";
+		? new Date(date).toLocaleString() : await translate("unknownTime");
 	appealMessage.messageId = -1;
 	appealMessage.senderIntId = senderIntId;
 	appealMessage.senderChatName = senderChatName;
@@ -695,7 +695,7 @@ function appendAppealMessage(container, displaySide, senderIntId, senderChatName
 }
 
 /** @param {import("./moderation-api.js").PunishmentRecord|null} record */
-function renderPlayerAppeal(record) {
+async function renderPlayerAppeal(record) {
 	currentPunishmentRecord = record;
 	punishmentAppealConversation.replaceChildren();
 	punishmentAppealConversation.hidden = true;
@@ -706,36 +706,36 @@ function renderPlayerAppeal(record) {
 	punishmentAppealLimit.textContent = "0 / 1000 bytes";
 
 	if (!record) {
-		punishmentAppeal.textContent = "This punishment could not be matched to an appealable record.";
+		punishmentAppeal.textContent = await translate("appealNotMatched");
 		return;
 	}
 	if (!record.appealMessage && record.finishDate > Date.now()) {
-		punishmentAppeal.textContent = "You may submit one appeal. It cannot be edited after submission.";
+		punishmentAppeal.textContent = await translate("appealSubmitOnce");
 		punishmentAppealForm.hidden = false;
 		return;
 	}
 	if (!record.appealMessage) {
-		punishmentAppeal.textContent = "This expired punishment was not appealed.";
+		punishmentAppeal.textContent = await translate("appealNotSubmitted");
 		return;
 	}
 
-	punishmentAppeal.textContent = `Appeal ${record.appealStatus}.`;
+	punishmentAppeal.textContent = await translate(`appeal${toCapitalised(record.appealStatus)}`);
 	punishmentAppealConversation.hidden = false;
-	appendAppealMessage(punishmentAppealConversation, "left", intId, chatName || "You",
+	await appendAppealMessage(punishmentAppealConversation, "left", intId, chatName || await translate("you"),
 		record.appealMessage, record.appealSubmittedAt);
 	if (record.appealStatus !== "pending") {
 		const knownModerator = typeof record.appealResponderIntId === "number" &&
 			Number.isInteger(record.appealResponderIntId) && record.appealResponderIntId >= 0;
 		const moderatorIntId = knownModerator ? record.appealResponderIntId : -1;
-		const moderatorName = knownModerator ? record.appealResponderChatName : "Unknown moderator";
-		appendAppealMessage(punishmentAppealConversation, "right", moderatorIntId, moderatorName,
-			record.appealResponse || "No response was recorded.", record.appealRespondedAt);
+		const moderatorName = knownModerator ? record.appealResponderChatName : await translate("unknownModerator");
+		await appendAppealMessage(punishmentAppealConversation, "right", moderatorIntId, moderatorName,
+			record.appealResponse || await translate("noResponseRecorded"), record.appealRespondedAt);
 	}
 }
 
 /** @param {{state:number, startDate:number, endDate:number}} info */
 async function loadPlayerAppeal(info) {
-	punishmentAppeal.textContent = "Loading appeal status...";
+	punishmentAppeal.textContent = await translate("loadingAppealStatus");
 	punishmentAppealForm.hidden = true;
 	try {
 		const data = await getOwnPunishments();
@@ -745,16 +745,16 @@ async function loadPlayerAppeal(info) {
 			Math.floor(record.startDate / 1000) * 1000 === info.startDate &&
 			Math.floor(record.finishDate / 1000) * 1000 === info.endDate);
 		const fallback = records.find(record => record.type === type && record.finishDate > Date.now());
-		renderPlayerAppeal(exact || fallback || null);
+		await renderPlayerAppeal(exact || fallback || null);
 	}
 	catch (error) {
 		currentPunishmentRecord = null;
-		punishmentAppeal.textContent = "Appeal service is unavailable on this server.";
+		punishmentAppeal.textContent = await translate("appealServiceUnavailable");
 		console.error("Couldn't load punishment appeal:", error);
 	}
 }
 
-window.addEventListener("punishment", (/**@type {Event}*/e) => {
+window.addEventListener("punishment", async (/**@type {Event}*/e) => {
 	if (!(e instanceof CustomEvent)) {
 		throw new Error("Window event was not of type CustomEvent");
 	}
@@ -765,20 +765,20 @@ window.addEventListener("punishment", (/**@type {Event}*/e) => {
 	else activePunishmentTypes.delete(type);
 
 	if (type === "mute") {
-		punishmentNote.innerHTML = "You have been <strong>muted</strong>, you cannot send messages in live chat.";
+		punishmentNote.innerHTML = await translate("mutedNotice");
 	}
 	else {
-		punishmentNote.innerHTML = "You have been <strong>banned</strong> from placing on the canvas or sending messages in live chat.";
+		punishmentNote.innerHTML = await translate("bannedNotice");
 	}
-	if (!active) punishmentNote.textContent = `Your ${type} has ended.`;
+	if (!active) punishmentNote.textContent = await translate(`${type}Ended`);
 	messageInput.disabled = activePunishmentTypes.size > 0;
-	if (activePunishmentTypes.has("ban")) setCanvasLocked(true, "You are currently banned from placing pixels.");
+	if (activePunishmentTypes.has("ban")) setCanvasLocked(true, await translate("bannedFromPlacing"));
 	else if (!canvasLocked && spectateStartState === null) setCanvasLocked(false);
 
-	punishmentUserId.textContent = `Your User ID: #${intId}`;
-	punishmentStartDate.textContent = `Started on: ${new Date(info.startDate).toLocaleString()}`;
-	punishmentEndDate.textContent = `Ending on: ${new Date(info.endDate).toLocaleString()}`;
-	punishmentReason.textContent = `Reason: ${info.reason}`;
+	punishmentUserId.textContent = `${await translate("yourUserId")} #${intId}`;
+	punishmentStartDate.textContent = `${await translate("startedOn")} ${new Date(info.startDate).toLocaleString()}`;
+	punishmentEndDate.textContent = `${await translate("endingOn")} ${new Date(info.endDate).toLocaleString()}`;
+	punishmentReason.textContent = `${await translate("reasonLabel")} ${info.reason}`;
 	void loadPlayerAppeal(info);
 	punishmentMenu.setAttribute("open", "true");
 });
@@ -796,16 +796,16 @@ punishmentAppealForm.addEventListener("submit", async event => {
 	if (byteLength === 0 || byteLength > 1000) return;
 	punishmentAppealMessage.disabled = true;
 	punishmentAppealSubmitButton.disabled = true;
-	punishmentAppeal.textContent = "Submitting appeal...";
+	punishmentAppeal.textContent = await translate("submittingAppeal");
 	try {
 		const result = await submitPunishmentAppeal(
 			currentPunishmentRecord.type, currentPunishmentRecord.punishmentId, message);
-		renderPlayerAppeal(result.appeal);
+		await renderPlayerAppeal(result.appeal);
 	}
 	catch (error) {
 		punishmentAppealMessage.disabled = false;
 		punishmentAppealSubmitButton.disabled = false;
-		punishmentAppeal.textContent = error instanceof Error ? error.message : "Could not submit appeal.";
+		punishmentAppeal.textContent = error instanceof Error ? error.message : await translate("couldNotSubmitAppeal");
 	}
 });
 window.addEventListener("spectating", (/**@type {Event}*/e) => {
@@ -882,9 +882,9 @@ placeContext.addEventListener("mousedown", function(e) {
 const placeContextReportButton = /**@type {HTMLButtonElement}*/($("#placeContextReportButton"));
 placeContextReportButton.disabled = !supportsCanvasPixelReports;
 if (!supportsCanvasPixelReports) {
-	placeContextReportButton.title = "Pixel reports are only available on the official server";
+	void translate("pixelReportsOfficialOnly").then(title => placeContextReportButton.title = title);
 }
-placeContextReportButton.addEventListener("click", function() {
+placeContextReportButton.addEventListener("click", async function() {
 	if (!supportsCanvasPixelReports) {
 		return;
 	}
@@ -897,10 +897,10 @@ placeContextReportButton.addEventListener("click", function() {
 	canvasReportPosition.textContent = `${pixelX}, ${pixelY}`;
 	canvasReportForm.reset();
 	canvasReportReason.disabled = !inBounds;
-	canvasReportStatus.textContent = inBounds ? "" : "This location is outside the canvas.";
+	canvasReportStatus.textContent = inBounds ? "" : await translate("outsideCanvas");
 	canvasReportStatus.hidden = inBounds;
 	canvasReportSubmitButton.disabled = true;
-	canvasReportCancelButton.textContent = "Cancel";
+	canvasReportCancelButton.textContent = await translate("cancel");
 	canvasReportLimit.textContent = "0 / 280 bytes";
 	if (!canvasReportDialog.open) {
 		canvasReportDialog.showModal();
@@ -931,7 +931,7 @@ async function showPlacerInfo(x, y) {
 	const pixelY = Math.floor(y);
 	const id = intIdPositions.get(pixelX + pixelY * WIDTH);
 
-	placerInfoStatus.textContent = "Looking up placer information...";
+	placerInfoStatus.textContent = await translate("lookingUpPlacer");
 	placerInfoStatus.hidden = false;
 	placerInfoDetails.hidden = true;
 	if (!placerInfoDialog.open) {
@@ -939,7 +939,7 @@ async function showPlacerInfo(x, y) {
 	}
 
 	if (id === undefined) {
-		placerInfoStatus.textContent = "Could not find details of who placed the pixel at this location.";
+		placerInfoStatus.textContent = await translate("couldNotFindPlacer");
 		return;
 	}
 	let name = intIdNames.get(id);
@@ -960,7 +960,7 @@ async function showPlacerInfo(x, y) {
 		}
 		catch(e) {
 			if (requestId === placerInfoRequestId) {
-				placerInfoStatus.textContent = "Could not find details of who placed the pixel at this location.";
+				placerInfoStatus.textContent = await translate("couldNotFindPlacer");
 			}
 			console.error("Couldn't show placer info:", e);
 			return;
@@ -986,12 +986,12 @@ canvasReportReason.addEventListener("input", function() {
 	canvasReportSubmitButton.disabled = byteLength === 0 || byteLength > 280;
 	canvasReportStatus.hidden = true;
 });
-canvasReportForm.addEventListener("submit", function(e) {
+canvasReportForm.addEventListener("submit", async function(e) {
 	e.preventDefault();
 	const reason = canvasReportReason.value.trim();
 	const byteLength = reportTextEncoder.encode(reason).byteLength;
 	if (selectedCanvasReportPosition === null || byteLength === 0 || byteLength > 280) {
-		canvasReportStatus.textContent = "Enter a report reason no longer than 280 bytes.";
+		canvasReportStatus.textContent = await translate("reportReasonTooLong");
 		canvasReportStatus.hidden = false;
 		return;
 	}
@@ -1002,12 +1002,12 @@ canvasReportForm.addEventListener("submit", function(e) {
 		}, e);
 		canvasReportReason.disabled = true;
 		canvasReportSubmitButton.disabled = true;
-		canvasReportCancelButton.textContent = "Close";
-		canvasReportStatus.textContent = "Report sent for moderator review.";
+		canvasReportCancelButton.textContent = await translate("close");
+		canvasReportStatus.textContent = await translate("reportSent");
 		canvasReportStatus.hidden = false;
 	}
 	catch(error) {
-		canvasReportStatus.textContent = "Could not send the report. Please reconnect and try again.";
+		canvasReportStatus.textContent = await translate("reportSendFailed");
 		canvasReportStatus.hidden = false;
 		console.error("Couldn't report canvas pixel:", error);
 	}
@@ -1429,7 +1429,7 @@ async function updatePlaceButton() {
 		const leftS = Math.floor(left / 1000);
 
 		if (!passkeyReadyForActions()) {
-			innerHTML = "Authenticate";
+			innerHTML = await translate("passkeyAuthenticate");
 			clearCooldownInterval();
 		}
 		else if (left > 0) {
@@ -2278,7 +2278,7 @@ modOptionsButton.addEventListener("click", async function() {
 });
 modMessageId.addEventListener("input", async function(e) {
 	// Show loading state immediately
-	modMessagePreview.textContent = "Loading message...";
+	modMessagePreview.textContent = await translate("loadingMessage");
 
 	// Check local cache first
 	let found = null;
@@ -2317,11 +2317,11 @@ modMessageId.addEventListener("input", async function(e) {
 				modMessagePreview.appendChild(messageElement);
 			}
 			else {
-				modMessagePreview.textContent = "Message not found";
+				modMessagePreview.textContent = await translate("messageNotFound");
 			}
 		}
 		catch (error) {
-			modMessagePreview.textContent = "Message not found";
+			modMessagePreview.textContent = await translate("messageNotFound");
 		}
 	}
 });
@@ -2382,6 +2382,10 @@ function closeChatModerate() {
 }
 modCloseButton.addEventListener("click", closeChatModerate);
 modCancelButton.addEventListener("click", closeChatModerate);
+const modReviewButton = /**@type {HTMLButtonElement}*/($("#modReviewButton"));
+modReviewButton.addEventListener("click", function() {
+	openModerationReview();
+});
 
 modActionForm.addEventListener("change", (e) => {
 	if (!(e.target instanceof HTMLInputElement)) {
@@ -2429,7 +2433,7 @@ function chatModerate(mode, senderId, messageId = null, messageElement = null) {
 	}
 }
 
-function renderModerationReview() {
+async function renderModerationReview() {
 	moderationReviewList.replaceChildren();
 	const records = moderationReviewRecords.get(moderationReviewType) || [];
 	for (const record of records) {
@@ -2440,8 +2444,8 @@ function renderModerationReview() {
 	}
 	if (records.length > 0) moderationReviewStatus.textContent = "";
 	else if (!moderationReviewLoading.has(moderationReviewType) &&
-		moderationReviewStatus.textContent === "Loading punishment records...") {
-		moderationReviewStatus.textContent = `No ${moderationReviewType} records found.`;
+		moderationReviewStatus.textContent === await translate("loadingPunishmentRecords")) {
+		moderationReviewStatus.textContent = await translate("noPunishmentRecords");
 	}
 	moderationReviewMoreButton.hidden = !moderationReviewHasMore.get(moderationReviewType);
 	moderationReviewMoreButton.disabled = moderationReviewLoading.has(moderationReviewType);
@@ -2455,7 +2459,7 @@ async function loadModerationReview(reset=false) {
 		moderationReviewOffsets.set(type, 0);
 		moderationReviewRecords.set(type, []);
 	}
-	moderationReviewStatus.textContent = "Loading punishment records...";
+	moderationReviewStatus.textContent = await translate("loadingPunishmentRecords");
 	moderationReviewMoreButton.disabled = true;
 	try {
 		const offset = moderationReviewOffsets.get(type) || 0;
@@ -2472,12 +2476,12 @@ async function loadModerationReview(reset=false) {
 	catch (error) {
 		if (type === moderationReviewType) {
 			moderationReviewStatus.textContent = error instanceof Error
-				? error.message : "Could not load punishment records.";
+				? error.message : await translate("couldNotLoadPunishmentRecords");
 		}
 	}
 	finally {
 		moderationReviewLoading.delete(type);
-		if (type === moderationReviewType) renderModerationReview();
+		if (type === moderationReviewType) await renderModerationReview();
 	}
 }
 
@@ -2513,7 +2517,7 @@ moderationReviewList.addEventListener("appeal-decision", async event => {
 	}
 	catch (error) {
 		recordElement.busy = false;
-		recordElement.errorMessage = error instanceof Error ? error.message : "Could not resolve appeal.";
+		recordElement.errorMessage = error instanceof Error ? error.message : await translate("couldNotResolveAppeal");
 		reloadAfterFailure = typeof error === "object" && error !== null &&
 			"status" in error && error.status === 409;
 	}
@@ -2697,12 +2701,12 @@ spectateUserIdInput.addEventListener("change", function(e) {
 });
 
 /**
- * @param {number} userIntId 
+ * @param {number} userIntId
  */
-function startedSpectating(userIntId) {
+async function startedSpectating(userIntId) {
 	spectateStartState = { x, y, z };
 	const spectatingChatName = intIdNames.get(userIntId);
-	spectateStatusLabel.textContent = "Spectating " + (spectatingChatName
+	spectateStatusLabel.textContent = (await translate("spectating")) + " " + (spectatingChatName
 		? `${spectatingChatName} (#${userIntId})`
 		: `#${userIntId}`);
 	setCanvasLocked(true);
@@ -2847,7 +2851,7 @@ overlayCopyButton.addEventListener("click", async function(e) {
 		], { duration: 1000, iterations: 1 });
 	}
 	else {
-		overlayCopyButton.children[2].textContent = "Failed: Overlay is too big!";
+		overlayCopyButton.children[2].textContent = await translate("overlayTooBig");
 		overlayCopyButton.children[2].animate([
 			{ opacity: 1 },
 			{ color: "red" }
@@ -2855,8 +2859,8 @@ overlayCopyButton.addEventListener("click", async function(e) {
 		if (overlayFailTimeout) {
 			clearTimeout(overlayFailTimeout);
 		}
-		overlayFailTimeout = setTimeout(() => {
-			overlayCopyButton.children[2].textContent = "Copied to clipboard!";
+		overlayFailTimeout = setTimeout(async () => {
+			overlayCopyButton.children[2].textContent = await translate("copiedToClipboard");
 		}, 1000)
 	}
 });
@@ -3002,12 +3006,12 @@ async function onChatContext(e, senderId, msgId) {
 			if (msgName[msgName.length - 1] === "~") {
 				msgName = msgName.slice(0, -1);
 				userNote.style.display = "block";
-				userNote.textContent = "This user is likely impersonating @" + msgName;
+				userNote.textContent = (await translate("impersonatingUser")) + msgName;
 			}
 			else if (msgName[msgName.length - 1] === "✓") {
 				msgName = msgName.slice(0, -1);
 				userNote.style.display = "block";
-				userNote.textContent = "This user is verified as @" + msgName;
+				userNote.textContent = (await translate("verifiedUser")) + msgName;
 			}
 			else {
 				userNote.style.display = "none";

--- a/src/shared.js
+++ b/src/shared.js
@@ -69,7 +69,187 @@ export const TRANSLATIONS = {
 		lockMessage: "This canvas is locked... You can't place pixels here anymore",
 		adHidden: "Ad hidden for 14 days!",
 		copiedToClipboard: "Copied to clipboard!",
-		
+		more: "More",
+		help: "Help",
+		confirmName: "Confirm name",
+		seePreviousMessages: "See previous messages",
+		sendQuicklyCtrlEnter: "Use the shortcut 'ctrl+enter' to send quickly",
+		sendQuicklyEnter: "Use the shortcut 'enter' to send quickly",
+		cancelReply: "Cancel reply",
+		addEmoji: "Add emoji",
+		addGif: "Add gif",
+		enableSounds: "Enable sounds",
+		enableCanvasChat: "Enable canvas chat",
+		cancel: "Cancel",
+		confirmPlacePixel: "Confirm place pixel",
+		openSecretSettings: "Open secret settings",
+		backToGame: "Back to game",
+
+		// Captcha
+		sorryForInterrupting: "🤔 Sorry for interrupting, but",
+		captchaClickEmoji: "Please click the button containing the emoji you see below",
+		generateNewCaptcha: "(generate new captcha)",
+		verifyingSession: "Verifying session...",
+		turnstileAutomatic: "Don't worry, this process should be automatic!",
+		completeCaptcha: "Complete captcha",
+		hcaptchaPrompt: "Please complete the below captcha to continue playing the game!",
+		continue: "Continue",
+
+		// Passkeys
+		passkeyAuthenticate: "Authenticate",
+		passkeyRequired: "Passkey required",
+		passkeyRequiredMessage: "Use a passkey to place pixels and send chat messages.",
+		passkeyInProgress: "Passkey in progress",
+		passkeyBrowserPrompt: "Follow your browser's passkey prompt to continue.",
+		waiting: "Waiting...",
+		passkeysUnavailable: "Passkeys unavailable",
+		passkeysUnsupportedMessage: "This browser or page cannot use passkeys. You can still spectate, but placing and chat are unavailable here.",
+		passkeysSecureSessionMessage: "This browser or page cannot use passkeys. Try a secure browser session on a passkey-capable device.",
+		unavailable: "Unavailable",
+		passkeyFailed: "Passkey failed",
+		passkeyFailedMessage: "Passkey authentication did not complete. You can try again.",
+		passkeyFailedDefault: "Passkey authentication did not complete.",
+		tryAgain: "Try again",
+
+		// Punishments
+		punishmentNotice: "Punishment notice:",
+		mutedNotice: "You have been <strong>muted</strong>, you cannot send messages in live chat.",
+		bannedNotice: "You have been <strong>banned</strong> from placing on the canvas or sending messages in live chat.",
+		muteEnded: "Your mute has ended.",
+		banEnded: "Your ban has ended.",
+		bannedFromPlacing: "You are currently banned from placing pixels.",
+		yourUserId: "Your User ID:",
+		startedOn: "Started on:",
+		endingOn: "Ending on:",
+		reasonLabel: "Reason:",
+		appeal: "Appeal",
+		appealPlaceholder: "Explain why this punishment should be reviewed",
+		submitAppeal: "Submit appeal",
+		appealNotMatched: "This punishment could not be matched to an appealable record.",
+		appealSubmitOnce: "You may submit one appeal. It cannot be edited after submission.",
+		appealNotSubmitted: "This expired punishment was not appealed.",
+		appealPending: "Appeal pending.",
+		appealApproved: "Appeal approved.",
+		appealDenied: "Appeal denied.",
+		loadingAppealStatus: "Loading appeal status...",
+		appealServiceUnavailable: "Appeal service is unavailable on this server.",
+		submittingAppeal: "Submitting appeal...",
+		couldNotSubmitAppeal: "Could not submit appeal.",
+		noResponseRecorded: "No response was recorded.",
+		unknownModerator: "Unknown moderator",
+		unknownPlayer: "Unknown player",
+		unknownTime: "Unknown time",
+		you: "You",
+
+		// Moderation
+		moderationOptions: "Moderation options:",
+		moderationOptionsAction: "Moderation options",
+		manage: "Manage:",
+		messageIdLabel: "Message ID:",
+		enterMessageId: "Enter Message ID",
+		userIdLabel: "User ID:",
+		enterUserId: "Enter User ID",
+		actionLabel: "Action:",
+		deleteMessage: "Delete message",
+		kick: "Kick",
+		mute: "Mute",
+		ban: "Ban",
+		captcha: "Captcha",
+		hours: "Hours",
+		minutes: "Minutes",
+		seconds: "Seconds",
+		applyToAllPlayers: "Apply to all players",
+		moderationWarning: "All moderation actions are logged by the server and reports sent to all other staff. Follow the moderation rules. Do not abuse power.",
+		reason: "Reason",
+		submit: "Submit",
+		loadingMessage: "Loading message...",
+		punishmentReview: "Punishment review",
+		punishmentReviewDescription: "Review mute and ban records and respond to appeals.",
+		mutes: "Mutes",
+		bans: "Bans",
+		loadMore: "Load 50 more",
+		loadingPunishmentRecords: "Loading punishment records...",
+		noPunishmentRecords: "No punishment records found.",
+		couldNotLoadPunishmentRecords: "Could not load punishment records.",
+		couldNotResolveAppeal: "Could not resolve appeal.",
+		moderatorResponse: "Moderator response",
+		explainDecision: "Explain the decision",
+		approve: "Approve",
+		deny: "Deny",
+		responseTooLong: "Enter a response no longer than 1000 bytes.",
+		punishment: "Punishment",
+		user: "User",
+		issuedBy: "Issued by",
+		started: "Started",
+		ends: "Ends",
+		expired: "Expired",
+		active: "Active",
+		unknownDate: "Unknown",
+
+		// Spectate
+		spectateLabel: "Spectate:",
+		spectateUser: "Spectate user:",
+		spectating: "Spectating",
+
+		// Advanced view
+		advancedViewOptions: "Advanced view options:",
+		selectionMode: "Selection mode:",
+		createSelection: "+ Create a selection",
+		renderLayers: "Render layers:",
+		renderLayersDescription: "Control what board layers are being rendered by the game:",
+		canvasLayer: "Canvas layer:",
+		changesLayer: "Changes layer:",
+		pixelsLayer: "Pixels layer:",
+
+		// Overlay
+		overlayLabel: "Overlay:",
+		overlayTooltip: "Make use of a canvas overlay image in order to help yourself better position your pixels",
+		imageX: "Image X:",
+		enterImageX: "Enter Image X",
+		imageY: "Image Y:",
+		enterImageY: "Enter Image Y",
+		imageOpacity: "Image Opacity:",
+		adjustOpacity: "Adjust opacity",
+		copyCanvasLink: "Copy canvas link",
+		copyOverlayUrl: "Copy overlay URL",
+		overlayTooBig: "Failed: Overlay is too big!",
+		selectImage: "Select image:",
+		share: "Share",
+		adjustImage: "Adjust image",
+		colourMatching: "Colour matching:",
+		nearestMatch: "Nearest match",
+		ignoreInvalidColours: "Ignore invalid colours",
+		imageOptions: "Image options:",
+		sharpenImageEdges: "Sharpen image edges",
+		flipImageX: "Flip image X",
+		flipImageY: "Flip image Y",
+
+		// Chat context & reports
+		impersonatingUser: "This user is likely impersonating @",
+		verifiedUser: "This user is verified as @",
+		addedBy: "Added by:",
+		reportHere: "Report here",
+		showPixelPlacerInfo: "Show pixel placer info",
+		moderateHere: "Moderate here",
+		pixelReportsOfficialOnly: "Pixel reports are only available on the official server",
+		reportPixel: "Report pixel",
+		reportPixelAt: "Report the player who placed the pixel at",
+		canvasReportPlaceholder: "Describe what should be reviewed",
+		submitReport: "Submit report",
+		close: "Close",
+		reportSent: "Report sent for moderator review.",
+		reportSendFailed: "Could not send the report. Please reconnect and try again.",
+		reportReasonTooLong: "Enter a report reason no longer than 280 bytes.",
+		outsideCanvas: "This location is outside the canvas.",
+
+		// Placer info
+		placerInfoTitle: "Pixel placer info",
+		lookingUpPlacer: "Looking up placer information...",
+		couldNotFindPlacer: "Could not find details of who placed the pixel at this location.",
+		position: "Position",
+		name: "Name",
+		userId: "User ID",
+
 		// Posts
 		rplaceLivePosts: "rplace.live posts",
 		searchKeyword: "Search keyword",
@@ -200,12 +380,22 @@ export async function translateAll() {
 	if (!translations) {
 		translations = await fetchTranslations(lang);
 	}
-	const elements = document.querySelectorAll("[translate]");
+	const elements = document.querySelectorAll("[translate], [translate-title]");
 	elements.forEach((element) => {
+		const titleKey = element.getAttribute("translate-title");
+		if (titleKey !== null) {
+			const title = translations?.[titleKey] ?? TRANSLATIONS["en"]?.[titleKey] ?? titleKey;
+			if (title) {
+				element.title = title;
+			}
+		}
 		const key = element.getAttribute("translate");
+		if (key === null) {
+			return;
+		}
 		const translation = translations?.[key] ?? TRANSLATIONS["en"]?.[key] ?? key;
 		if (element instanceof HTMLInputElement) {
-			if (element.type === "text") {
+			if (element.type === "text" || element.hasAttribute("placeholder")) {
 				element.placeholder = translation || element.placeholder;
 			}
 			else {


### PR DESCRIPTION
Wire the translation system across the main game page per `agent-context/i18n-game-page-review.md`:

- Add ~170 new English keys to `TRANSLATIONS.en` (`src/shared.js`) covering passkey, punishment/appeal, moderation, spectate, overlay, captcha and report strings
- Extend `translateAll()` with a `translate-title` attribute for tooltips and placeholder translation for non-text inputs
- Add `translate`/`translate-title` attributes throughout `index.html` (HUD buttons, chat panel, moderation, review, captcha, report and overlay menus)
- Replace hardcoded English literals with `translate()` calls in `index.js` and `game-elements.js`, including the missing "Moderation options" action-button key
- Add a punishment review button to the moderation menu that opens the Shift+R moderation review dialog

Alerts, console logs, debug flows and one-off event strings are intentionally excluded. Locale files for other languages are left for follow-up community/machine translations.