### PR TITLE
feat(chat): cross-channel mentions + linked vanity UI (#369)

### DIFF
--- a/index.html
+++ b/index.html
@@ -207,6 +207,7 @@
 					<div class="message-input-container">
 						<r-emoji-panel id="messageInputEmojiPanel" class="chat-bottom-panel"></r-emoji-panel>
 						<r-gif-panel id="messageInputGifPanel" class="chat-bottom-panel"></r-gif-panel>
+						<div id="messageInputMirror" aria-hidden="true"></div>
 						<textarea id="messageInput" type="text" placeholder="Enter message..." translate="enterMessage" enterkeyhint="send" maxlength="200"></textarea>
 						<div class="message-input-actions">
 							<button type="button" id="messageAddEmojiButton" title="Add emoji">

--- a/public/css/rplace-2022.css
+++ b/public/css/rplace-2022.css
@@ -315,6 +315,15 @@ dialog {
 	padding-top: 8px;
 	height: max(36px, var(--message-input-height));
 }
+#messageInputMirror {
+	padding: 8px 5px 5px;
+	border: 0 solid transparent;
+	border-radius: 10px;
+	font-family: bold;
+}
+:root[data-variant="dark"] #messageInputMirror {
+	border-width: 1px;
+}
 #messageInput[state="command"] {
 	color: #00FA9A;
 }

--- a/public/css/rplace-2023.css
+++ b/public/css/rplace-2023.css
@@ -366,6 +366,11 @@ r-close-icon {
 	padding-top: 8px;
 	padding-right: 58px;
 }
+#messageInputMirror {
+	padding: 8px 58px 4px 4px;
+	border: var(--pixel-border-size) solid transparent;
+	font-family: var(--font-pixel);
+}
 #messageTypePanel {
 	height: calc(var(--message-input-height) + 72px);
 }

--- a/src/pages/index/chat-helpers.js
+++ b/src/pages/index/chat-helpers.js
@@ -32,12 +32,12 @@ export function normaliseBlockedUsers(list) {
 	if (!Array.isArray(list)) return [];
 	const out = [];
 	const seen = new Set();
-	for (const v of list) {
-		const n = Number(v);
-		if (!Number.isFinite(n) || n === 0) continue;
-		if (seen.has(n)) continue;
-		seen.add(n);
-		out.push(n);
+	for (const rawEntry of list) {
+		const numericId = Number(rawEntry);
+		if (!Number.isFinite(numericId) || numericId === 0) continue;
+		if (seen.has(numericId)) continue;
+		seen.add(numericId);
+		out.push(numericId);
 	}
 	return out;
 }
@@ -46,9 +46,4 @@ export function normaliseBlockedUsers(list) {
 export function isBlocked(senderIntId, blockedList) {
 	if (!Array.isArray(blockedList) || blockedList.length === 0) return false;
 	return blockedList.includes(Number(senderIntId));
-}
-
-/** @param {string} channel @returns {boolean} */
-export function isLanguageChannel(channel) {
-	return typeof channel === "string" && !channel.startsWith("group:");
 }

--- a/src/pages/index/chat-helpers.js
+++ b/src/pages/index/chat-helpers.js
@@ -12,29 +12,52 @@ function escapeRegExp(value) {
 export function isMention(content, chatName, intId) {
 	if (!content || typeof content !== "string") return false;
 	if (!content.includes("@")) return false;
-	if (/(^|[^a-zA-Z0-9_])@everyone\b/i.test(content)) return true;
+	if (/(^|[^a-zA-Z0-9_])@everyone(?![a-zA-Z0-9_])/i.test(content)) return true;
 	if (intId != null && Number.isFinite(intId)) {
-		const idPattern = new RegExp("(^|[^a-zA-Z0-9_])@#" + escapeRegExp(String(intId)) + "\\b");
+		const idPattern = new RegExp("(^|[^a-zA-Z0-9_])@#" + escapeRegExp(String(intId)) + "(?![a-zA-Z0-9_])");
 		if (idPattern.test(content)) return true;
 	}
 	if (chatName) {
 		const name = String(chatName).trim();
 		if (name.length > 0) {
-			const namePattern = new RegExp("(^|[^a-zA-Z0-9_])@" + escapeRegExp(name) + "\\b", "i");
+			const namePattern = new RegExp("(^|[^a-zA-Z0-9_])@" + escapeRegExp(name) + "(?![a-zA-Z0-9_])", "i");
 			if (namePattern.test(content)) return true;
 		}
 	}
 	return false;
 }
 
-/** @param {string[]|number[]} list @returns {number[]} */
+/** @param {number} intId @returns {string} */
+export function formatMention(intId) {
+	return `@#${intId}`;
+}
+
+/**
+ * @param {string} value
+ * @param {number} cursor
+ * @returns {{ query: string; start: number; end: number }|null}
+ */
+export function findMentionQuery(value, cursor) {
+	if (typeof value !== "string" || !Number.isSafeInteger(cursor)) return null;
+	const boundedCursor = Math.min(Math.max(cursor, 0), value.length);
+	const match = value.slice(0, boundedCursor)
+		.match(/(^|[^a-zA-Z0-9_])@([a-zA-Z0-9_]{0,16})$/);
+	if (!match) return null;
+	return {
+		query: match[2].toLowerCase(),
+		start: boundedCursor - match[2].length - 1,
+		end: boundedCursor
+	};
+}
+
+/** @param {(string|number)[]} list @returns {number[]} */
 export function normaliseBlockedUsers(list) {
 	if (!Array.isArray(list)) return [];
 	const out = [];
 	const seen = new Set();
 	for (const rawEntry of list) {
 		const numericId = Number(rawEntry);
-		if (!Number.isFinite(numericId) || numericId === 0) continue;
+		if (!Number.isSafeInteger(numericId) || numericId <= 0) continue;
 		if (seen.has(numericId)) continue;
 		seen.add(numericId);
 		out.push(numericId);

--- a/src/pages/index/chat-helpers.js
+++ b/src/pages/index/chat-helpers.js
@@ -1,7 +1,14 @@
+/** @param {string} value */
 function escapeRegExp(value) {
 	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+/**
+ * @param {string} content
+ * @param {string|null|undefined} chatName
+ * @param {number|null|undefined} intId
+ * @returns {boolean}
+ */
 export function isMention(content, chatName, intId) {
 	if (!content || typeof content !== "string") return false;
 	if (!content.includes("@")) return false;
@@ -20,6 +27,7 @@ export function isMention(content, chatName, intId) {
 	return false;
 }
 
+/** @param {string[]|number[]} list @returns {number[]} */
 export function normaliseBlockedUsers(list) {
 	if (!Array.isArray(list)) return [];
 	const out = [];
@@ -34,11 +42,13 @@ export function normaliseBlockedUsers(list) {
 	return out;
 }
 
+/** @param {number} senderIntId @param {number[]} blockedList @returns {boolean} */
 export function isBlocked(senderIntId, blockedList) {
 	if (!Array.isArray(blockedList) || blockedList.length === 0) return false;
 	return blockedList.includes(Number(senderIntId));
 }
 
+/** @param {string} channel @returns {boolean} */
 export function isLanguageChannel(channel) {
 	return typeof channel === "string" && !channel.startsWith("group:");
 }

--- a/src/pages/index/chat-helpers.js
+++ b/src/pages/index/chat-helpers.js
@@ -3,6 +3,9 @@ function escapeRegExp(value) {
 	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+/** @typedef {{ start: number; end: number; label: string; intId: number }} MentionToken */
+/** @typedef {{ start: number; oldEnd: number; newEnd: number }} TextEdit */
+
 /**
  * @param {string} content
  * @param {string|null|undefined} chatName
@@ -48,6 +51,78 @@ export function findMentionQuery(value, cursor) {
 		start: boundedCursor - match[2].length - 1,
 		end: boundedCursor
 	};
+}
+
+/**
+ * @param {string} previousValue
+ * @param {string} nextValue
+ * @returns {TextEdit|null}
+ */
+export function findTextEdit(previousValue, nextValue) {
+	if (previousValue === nextValue) return null;
+	let start = 0;
+	while (start < previousValue.length && start < nextValue.length &&
+		previousValue[start] === nextValue[start]) {
+		start++;
+	}
+
+	let oldEnd = previousValue.length;
+	let newEnd = nextValue.length;
+	while (oldEnd > start && newEnd > start &&
+		previousValue[oldEnd - 1] === nextValue[newEnd - 1]) {
+		oldEnd--;
+		newEnd--;
+	}
+	return { start, oldEnd, newEnd };
+}
+
+/**
+ * @param {MentionToken[]} tokens
+ * @param {TextEdit|null} edit
+ * @returns {MentionToken[]}
+ */
+export function rebaseMentionTokens(tokens, edit) {
+	if (!edit) return tokens;
+	const offset = edit.newEnd - edit.oldEnd;
+	const rebased = [];
+	for (const token of tokens) {
+		if (token.end <= edit.start) {
+			rebased.push(token);
+		}
+		else if (token.start >= edit.oldEnd) {
+			rebased.push({ ...token, start: token.start + offset, end: token.end + offset });
+		}
+	}
+	return rebased;
+}
+
+/**
+ * @param {string} value
+ * @param {MentionToken[]} tokens
+ * @returns {string}
+ */
+export function serialiseMentionTokens(value, tokens) {
+	const validTokens = tokens
+		.filter(token => Number.isSafeInteger(token.start) && Number.isSafeInteger(token.end) &&
+			token.start >= 0 && token.end > token.start && token.end <= value.length &&
+			Number.isSafeInteger(token.intId) && token.intId > 0 && token.intId <= 0xFFFFFFFF &&
+			value.slice(token.start, token.end) === token.label)
+		.sort((first, second) => first.start - second.start);
+
+	let previousEnd = 0;
+	const nonOverlappingTokens = validTokens.filter(token => {
+		if (token.start < previousEnd) return false;
+		previousEnd = token.end;
+		return true;
+	});
+
+	let serialised = value;
+	for (let index = nonOverlappingTokens.length - 1; index >= 0; index--) {
+		const token = nonOverlappingTokens[index];
+		serialised = serialised.slice(0, token.start) + formatMention(token.intId) +
+			serialised.slice(token.end);
+	}
+	return serialised;
 }
 
 /** @param {(string|number)[]} list @returns {number[]} */

--- a/src/pages/index/chat-helpers.js
+++ b/src/pages/index/chat-helpers.js
@@ -1,0 +1,44 @@
+function escapeRegExp(value) {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function isMention(content, chatName, intId) {
+	if (!content || typeof content !== "string") return false;
+	if (!content.includes("@")) return false;
+	if (/(^|[^a-zA-Z0-9_])@everyone\b/i.test(content)) return true;
+	if (intId != null && Number.isFinite(intId)) {
+		const idPattern = new RegExp("(^|[^a-zA-Z0-9_])@#" + escapeRegExp(String(intId)) + "\\b");
+		if (idPattern.test(content)) return true;
+	}
+	if (chatName) {
+		const name = String(chatName).trim();
+		if (name.length > 0) {
+			const namePattern = new RegExp("(^|[^a-zA-Z0-9_])@" + escapeRegExp(name) + "\\b", "i");
+			if (namePattern.test(content)) return true;
+		}
+	}
+	return false;
+}
+
+export function normaliseBlockedUsers(list) {
+	if (!Array.isArray(list)) return [];
+	const out = [];
+	const seen = new Set();
+	for (const v of list) {
+		const n = Number(v);
+		if (!Number.isFinite(n) || n === 0) continue;
+		if (seen.has(n)) continue;
+		seen.add(n);
+		out.push(n);
+	}
+	return out;
+}
+
+export function isBlocked(senderIntId, blockedList) {
+	if (!Array.isArray(blockedList) || blockedList.length === 0) return false;
+	return blockedList.includes(Number(senderIntId));
+}
+
+export function isLanguageChannel(channel) {
+	return typeof channel === "string" && !channel.startsWith("group:");
+}

--- a/src/pages/index/chat-helpers.test.js
+++ b/src/pages/index/chat-helpers.test.js
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import { findMentionQuery, formatMention, isBlocked, isMention, normaliseBlockedUsers } from "./chat-helpers.js";
+
+describe("chat mention helpers", () => {
+	test("matches stable IDs, names and everyone at token boundaries", () => {
+		expect(isMention("hello @#42", "alice", 42)).toBe(true);
+		expect(isMention("hello @ALICE!", "alice", 42)).toBe(true);
+		expect(isMention("hello @everyone", "alice", 42)).toBe(true);
+		expect(isMention("email test@alice.com", "alice", 42)).toBe(false);
+		expect(isMention("not @#420", "alice", 42)).toBe(false);
+	});
+
+	test("matches server-decorated names without accepting longer names", () => {
+		expect(isMention("hello @alice~", "alice~", 42)).toBe(true);
+		expect(isMention("hello @alice✓", "alice✓", 42)).toBe(true);
+		expect(isMention("hello @alice✓extra", "alice✓", 42)).toBe(false);
+	});
+
+	test("formats canonical identity tokens", () => {
+		expect(formatMention(42)).toBe("@#42");
+	});
+
+	test("finds the active name query at the cursor without matching emails", () => {
+		expect(findMentionQuery("hello @Ali world", 10)).toEqual({ query: "ali", start: 6, end: 10 });
+		expect(findMentionQuery("@", 1)).toEqual({ query: "", start: 0, end: 1 });
+		expect(findMentionQuery("test@ali", 8)).toBeNull();
+		expect(findMentionQuery("hello @#42", 10)).toBeNull();
+	});
+});
+
+describe("blocked-user helpers", () => {
+	test("normalises positive integer IDs and removes duplicates", () => {
+		expect(normaliseBlockedUsers(["12", 12, "-1", "1.5", "nope", 0, 23])).toEqual([12, 23]);
+		expect(isBlocked(12, [12, 23])).toBe(true);
+		expect(isBlocked(7, [12, 23])).toBe(false);
+	});
+});

--- a/src/pages/index/chat-helpers.test.js
+++ b/src/pages/index/chat-helpers.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { findMentionQuery, formatMention, isBlocked, isMention, normaliseBlockedUsers } from "./chat-helpers.js";
+import { findMentionQuery, findTextEdit, formatMention, isBlocked, isMention,
+	normaliseBlockedUsers, rebaseMentionTokens, serialiseMentionTokens } from "./chat-helpers.js";
 
 describe("chat mention helpers", () => {
 	test("matches stable IDs, names and everyone at token boundaries", () => {
@@ -25,6 +26,42 @@ describe("chat mention helpers", () => {
 		expect(findMentionQuery("@", 1)).toEqual({ query: "", start: 0, end: 1 });
 		expect(findMentionQuery("test@ali", 8)).toBeNull();
 		expect(findMentionQuery("hello @#42", 10)).toBeNull();
+	});
+
+	test("rebases intact tokens through a contiguous edit", () => {
+		const tokens = [
+			{ start: 0, end: 6, label: "@alice", intId: 12 },
+			{ start: 10, end: 14, label: "@bob", intId: 23 }
+		];
+		const edit = findTextEdit("@alice hi @bob", "Well @alice hi @bob");
+		expect(edit).toEqual({ start: 0, oldEnd: 0, newEnd: 5 });
+		expect(rebaseMentionTokens(tokens, edit)).toEqual([
+			{ start: 5, end: 11, label: "@alice", intId: 12 },
+			{ start: 15, end: 19, label: "@bob", intId: 23 }
+		]);
+	});
+
+	test("drops only tokens touched by an edit", () => {
+		const tokens = [
+			{ start: 0, end: 6, label: "@alice", intId: 12 },
+			{ start: 10, end: 14, label: "@bob", intId: 23 }
+		];
+		const edit = findTextEdit("@alice hi @bob", "@alicia hi @bob");
+		expect(rebaseMentionTokens(tokens, edit)).toEqual([
+			{ start: 11, end: 15, label: "@bob", intId: 23 }
+		]);
+		expect(rebaseMentionTokens([tokens[0]], { start: 0, oldEnd: 6, newEnd: 6 })).toEqual([]);
+	});
+
+	test("serialises multiple intact vanity tokens from right to left", () => {
+		const value = "@alice met @alice and @bob";
+		const tokens = [
+			{ start: 0, end: 6, label: "@alice", intId: 12 },
+			{ start: 11, end: 17, label: "@alice", intId: 34 },
+			{ start: 22, end: 26, label: "@bob", intId: 23 }
+		];
+		expect(serialiseMentionTokens(value, tokens)).toBe("@#12 met @#34 and @#23");
+		expect(serialiseMentionTokens("@alicia", [tokens[0]])).toBe("@alicia");
 	});
 });
 

--- a/src/pages/index/game-elements.js
+++ b/src/pages/index/game-elements.js
@@ -4,6 +4,9 @@ import { until } from "lit/directives/until.js";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { CHAT_COLOURS, EMOJIS, CUSTOM_EMOJIS } from "../../defaults.js";
 import { sanitise, translate, hash, markdownParse } from "../../shared.js";
+import { intIdNames } from "./game-state.js";
+
+let nextMentionPopoverId = 0;
 
 export class PositionIndicator extends HTMLElement {
 	#root
@@ -99,6 +102,64 @@ export class LiveChatMouseEvent extends MouseEvent {
 	}
 }
 
+class ChatMention extends LitElement {
+	static properties = {
+		intId: { type: Number, attribute: "intid" }
+	};
+
+	#popoverId
+	#anchorName
+
+	constructor() {
+		super()
+		this.intId = 0
+		this.#popoverId = `chat-mention-popover-${++nextMentionPopoverId}`
+		this.#anchorName = `--${this.#popoverId}`
+	}
+
+	createRenderRoot() {
+		return this
+	}
+
+	/** @param {Event} event */
+	#showPopover(event) {
+		const trigger = /**@type {HTMLElement|null}*/(event.currentTarget)
+		const popover = /**@type {HTMLElement|null}*/(trigger?.nextElementSibling)
+		if (popover?.showPopover && !popover.matches(":popover-open")) {
+			popover.showPopover()
+		}
+	}
+
+	/** @param {Event} event */
+	#hidePopover(event) {
+		const trigger = /**@type {HTMLElement|null}*/(event.currentTarget)
+		const popover = /**@type {HTMLElement|null}*/(trigger?.nextElementSibling)
+		if (popover?.hidePopover && popover.matches(":popover-open")) {
+			popover.hidePopover()
+		}
+	}
+
+	render() {
+		const mentionedName = intIdNames.get(this.intId) || null
+		const displayName = mentionedName || `#${this.intId}`
+		return html`
+			<span class="chat-mention" role="button" tabindex="0"
+				aria-describedby=${this.#popoverId}
+				style=${styleMap({ "anchor-name": this.#anchorName })}
+				@mouseenter=${this.#showPopover}
+				@mouseleave=${this.#hidePopover}
+				@focus=${this.#showPopover}
+				@blur=${this.#hidePopover}
+				@click=${this.#showPopover}>@${displayName}</span>
+			<span id=${this.#popoverId} class="chat-mention-popover" popover="auto"
+				style=${styleMap({ "position-anchor": this.#anchorName })}>
+				<span>${mentionedName ? `@${mentionedName}` : "Unknown name"}</span>
+				<span>#${this.intId}</span>
+			</span>`
+	}
+}
+customElements.define("r-chat-mention", ChatMention);
+
 
 export class LiveChatMessage extends LitElement {
 	static properties = {
@@ -169,6 +230,11 @@ export class LiveChatMessage extends LitElement {
 			const size = isLargeEmoji ? "48" : "16"
 			return `<img src="custom_emojis/${source}.png" alt=":${source}:" title=":${source}:" width="${size}" height="${size}">`;
 		})	
+		parsedHTML = parsedHTML.replaceAll(/@#(\d+)(?![a-zA-Z0-9_])/g, (full, source) => {
+			const mentionedId = Number(source)
+			if (!Number.isSafeInteger(mentionedId) || mentionedId > 0xFFFFFFFF) return full
+			return `<r-chat-mention intid="${mentionedId}"></r-chat-mention>`
+		})
 
 		// Handle coordinates and generate final lit HTML
 		const formattedMessage = this.#parseCoordinates(parsedHTML);
@@ -176,7 +242,6 @@ export class LiveChatMessage extends LitElement {
 	}
 
 	/**
-	 * 
 	 * @param {string} parsedHTML 
 	 * @returns {any} Lit HTML fragment
 	 */
@@ -189,19 +254,17 @@ export class LiveChatMessage extends LitElement {
 			const [fullMatch, x, y] = match
 			const startIndex = match.index
 
-			// Push the text before the match
 			if (startIndex > lastIndex) {
 				parts.push(unsafeHTML(parsedHTML.slice(lastIndex, startIndex)))
 			}
 
 			const href = `${window.location.pathname}?x=${x}&y=${y}`
-			parts.push(html`<a href="${href}" @click=${(/**@type {MouseEvent}*/e) => 
+			parts.push(html`<a href="${href}" @click=${(/**@type {MouseEvent}*/e) =>
 				this.#notifyCoordinateClick(e, parseInt(x, 10), parseInt(y, 10))}>${x},${y}</a>`)
 
 			lastIndex = startIndex + fullMatch.length
 		}
 
-		// Push any text following matches
 		if (lastIndex < parsedHTML.length) {
 			parts.push(unsafeHTML(parsedHTML.slice(lastIndex)))
 		}

--- a/src/pages/index/index.js
+++ b/src/pages/index/index.js
@@ -14,7 +14,8 @@ import { theme } from "./game-themes.js";
 import { BOARD, canvasLocked, CHANGES, chatName, connectStatus, COOLDOWN, cooldownEndDate, HEIGHT, intId, intIdNames, intIdPositions, onCooldown, PALETTE, PALETTE_USABLE_REGION, passkeyAuthState, placementMode, RAW_BOARD, setCooldown, setPasskeyAuthState, setPlacementMode, SOCKET_PIXELS, supportsCanvasPixelReports, WIDTH, placePixel, sendDefaultCaptchaResult, sendServerMessage, setDefaultCaptchaHandlers, makeServerRequest, connect } from "./game-state.js";
 import { generateIndicators, generatePalette, hideIndicators, showPalette } from "./palette.js";
 import { authenticatePasskey, getPasskeyStatus, registerPasskey, supportsPasskeys } from "./passkeys.js";
-import { findMentionQuery, formatMention, isMention, normaliseBlockedUsers, isBlocked } from "./chat-helpers.js";
+import { findMentionQuery, findTextEdit, formatMention, isMention, normaliseBlockedUsers,
+	isBlocked, rebaseMentionTokens, serialiseMentionTokens } from "./chat-helpers.js";
 import "./popup.js";
 
 import FingerprintJS from "@fingerprintjs/fingerprintjs";
@@ -123,7 +124,8 @@ const passkeyMenu = /**@type {HTMLElement}*/($("#passkeyMenu"));
 const passkeyMenuTitle = /**@type {HTMLElement}*/($("#passkeyMenuTitle"));
 const passkeyMenuMessage = /**@type {HTMLElement}*/($("#passkeyMenuMessage"));
 const passkeyMenuButton = /**@type {HTMLButtonElement}*/($("#passkeyMenuButton"));
-const messageInput = /**@type {HTMLInputElement}*/($("#messageInput"));
+const messageInput = /**@type {HTMLTextAreaElement}*/($("#messageInput"));
+const messageInputMirror = /**@type {HTMLElement}*/($("#messageInputMirror"));
 const messageTypePanel = /**@type {HTMLElement}*/($("#messageTypePanel"));
 const messageInputGifPanel = /**@type {import("../../shared-elements.js").GifPanel}*/($("#messageInputGifPanel"));
 const messageReplyPanel = /**@type {HTMLElement}*/($("#messageReplyPanel"));
@@ -2118,6 +2120,71 @@ chatPreviousButton.addEventListener("click", () => {
 	chatPreviousAutoLoad = true	;
 })
 
+/** @type {import("./chat-helpers.js").MentionToken[]} */
+let messageMentionTokens = [];
+let previousMessageInputValue = messageInput.value;
+
+function renderMessageInputMirror() {
+	let previousTokenEnd = 0;
+	messageMentionTokens = messageMentionTokens
+		.filter(token => token.start >= 0 && token.end <= messageInput.value.length &&
+			messageInput.value.slice(token.start, token.end) === token.label)
+		.sort((first, second) => first.start - second.start)
+		.filter(token => {
+			if (token.start < previousTokenEnd) return false;
+			previousTokenEnd = token.end;
+			return true;
+		});
+
+	const fragment = document.createDocumentFragment();
+	let currentIndex = 0;
+	for (const token of messageMentionTokens) {
+		fragment.append(document.createTextNode(messageInput.value.slice(currentIndex, token.start)));
+		const highlight = document.createElement("span");
+		highlight.className = "linked-mention";
+		highlight.textContent = token.label;
+		fragment.append(highlight);
+		currentIndex = token.end;
+	}
+	fragment.append(document.createTextNode(messageInput.value.slice(currentIndex)));
+	messageInputMirror.replaceChildren(fragment);
+	messageInputMirror.scrollTop = messageInput.scrollTop;
+	messageInputMirror.scrollLeft = messageInput.scrollLeft;
+}
+
+function syncMessageInputValue() {
+	const nextValue = messageInput.value;
+	messageMentionTokens = rebaseMentionTokens(messageMentionTokens,
+		findTextEdit(previousMessageInputValue, nextValue));
+	previousMessageInputValue = nextValue;
+	renderMessageInputMirror();
+}
+
+/** @param {string} value */
+function setMessageInputValue(value) {
+	messageInput.value = value;
+	syncMessageInputValue();
+	updateMessageInputHeight();
+}
+
+function clearMessageInput() {
+	messageInput.value = "";
+	previousMessageInputValue = "";
+	messageMentionTokens = [];
+	renderMessageInputMirror();
+	updateMessageInputHeight();
+}
+
+function getMessageInputWireValue() {
+	return serialiseMentionTokens(messageInput.value, messageMentionTokens);
+}
+
+messageInput.addEventListener("scroll", () => {
+	messageInputMirror.scrollTop = messageInput.scrollTop;
+	messageInputMirror.scrollLeft = messageInput.scrollLeft;
+});
+renderMessageInputMirror();
+
 messageInput.addEventListener("keydown", function(/**@type {KeyboardEvent}*/ e) {
 	if (!(e instanceof Event) || !e.isTrusted) {
 		return;
@@ -2135,12 +2202,11 @@ messageInput.addEventListener("keydown", function(/**@type {KeyboardEvent}*/ e) 
 			sent = sendPlaceChatMsg(messageInput.value, e);
 		}
 		else {
-			sent = sendLiveChatMsg(messageInput.value, e);
+			sent = sendLiveChatMsg(getMessageInputWireValue(), e);
 		}
 		e.preventDefault()
 		if (sent) {
-			messageInput.value = ""
-			updateMessageInputHeight()
+			clearMessageInput()
 		}
 	}
 });
@@ -2148,18 +2214,37 @@ messageInput.addEventListener("focus", openChatPanel);
 
 /**
  * @param {string} text
+ * @returns {{ start: number; end: number }}
  */
 function chatInsertText(text) {
-	const [ start, end ] = [ messageInput.selectionStart, messageInput.selectionEnd ]
-	messageInput.setRangeText(text, start || 0, end || 0, "end")
+	const [ start, end ] = [ messageInput.selectionStart ?? 0, messageInput.selectionEnd ?? 0 ]
+	messageInput.setRangeText(text, start, end, "end")
+	messageMentionTokens = rebaseMentionTokens(messageMentionTokens, {
+		start,
+		oldEnd: end,
+		newEnd: start + text.length
+	})
+	previousMessageInputValue = messageInput.value
+	renderMessageInputMirror()
+	updateMessageInputHeight()
 	messageInput.focus()
+	return { start, end: start + text.length }
 }
 
 /**
  * @param {number} senderId
  */
 function chatMentionUser(senderId) {
-	chatInsertText(formatMention(senderId) + " ")
+	if (!Number.isSafeInteger(senderId) || senderId <= 0) return;
+	const label = `@${intIdNames.get(senderId) || `#${senderId}`}`;
+	const insertedRange = chatInsertText(label + " ");
+	messageMentionTokens.push({
+		start: insertedRange.start,
+		end: insertedRange.start + label.length,
+		label,
+		intId: senderId
+	});
+	renderMessageInputMirror();
 }
 
 messageTypePanel.children[0].addEventListener("click", function (/**@type {Event}*/e) {
@@ -2168,7 +2253,7 @@ messageTypePanel.children[0].addEventListener("click", function (/**@type {Event
 	}
 
 	if (sendPlaceChatMsg(messageInput.value, e)) {
-		messageInput.value = "";
+		clearMessageInput();
 	}
 });
 messageTypePanel.children[1].addEventListener("click", function(/**@type {Event}*/e) {
@@ -2176,8 +2261,8 @@ messageTypePanel.children[1].addEventListener("click", function(/**@type {Event}
 		return;
 	}
 
-	if (sendLiveChatMsg(messageInput.value, e)) {
-		messageInput.value = "";
+	if (sendLiveChatMsg(getMessageInputWireValue(), e)) {
+		clearMessageInput();
 	}
 });
 
@@ -2616,7 +2701,7 @@ function showMentionSuggestions(mentionQuery) {
 
 		entryElement.addEventListener("click", function() {
 			messageInput.setSelectionRange(mentionQuery.start, mentionQuery.end);
-			chatInsertText(formatMention(userId) + " ");
+			chatMentionUser(userId);
 			closeMessageEmojisPanel();
 			updateMessageInputHeight();
 		});
@@ -2650,6 +2735,7 @@ messageInput.oninput = (/** @type {{ isTrusted: any; }} */ e) => {
 	if (!e.isTrusted) {
 		return;
 	}
+	syncMessageInputValue();
 	updateMessageInputHeight();
 
 	messageEmojisPanel.innerHTML = "";
@@ -2714,7 +2800,7 @@ messageInput.oninput = (/** @type {{ isTrusted: any; }} */ e) => {
 			entryElement.addEventListener("click", function() {
 				for (let i = messageInput.value.length - 1; i >= 0; i--) {
 					if (messageInput.value[i] == ":") {
-						messageInput.value = messageInput.value.slice(0, i) + value;
+						setMessageInputValue(messageInput.value.slice(0, i) + value);
 						closeMessageEmojisPanel();
 						break
 					}
@@ -2725,7 +2811,7 @@ messageInput.oninput = (/** @type {{ isTrusted: any; }} */ e) => {
 		}
 
 		if (messageInput.value.includes(":" + emojiCode + ":")) {
-			messageInput.value = messageInput.value.replace(":" + emojiCode + ":", value);
+			setMessageInputValue(messageInput.value.replace(":" + emojiCode + ":", value));
 			messageInput.setAttribute("state", "default");
 			handled = true;
 		}
@@ -2737,7 +2823,7 @@ messageInput.oninput = (/** @type {{ isTrusted: any; }} */ e) => {
 			entryElement.addEventListener("click", function() {
 				for (let i = messageInput.value.length - 1; i >= 0; i--) {
 					if (messageInput.value[i] == ":") {
-						messageInput.value = messageInput.value.slice(0, i) + ":" + emojiCode + ":";
+						setMessageInputValue(messageInput.value.slice(0, i) + ":" + emojiCode + ":");
 						closeMessageEmojisPanel();
 						break;
 					}
@@ -2761,7 +2847,7 @@ messageInput.oninput = (/** @type {{ isTrusted: any; }} */ e) => {
 			entryLabel.textContent = `:${commandCode}`;
 			entryElement.appendChild(entryLabel);
 			entryElement.addEventListener("click", function() {
-				messageInput.value = ":" + commandCode;
+				setMessageInputValue(":" + commandCode);
 				closeMessageEmojisPanel();
 			})
 			entryElement.appendChild(stringToHtml(value))

--- a/src/pages/index/index.js
+++ b/src/pages/index/index.js
@@ -14,7 +14,7 @@ import { theme } from "./game-themes.js";
 import { BOARD, canvasLocked, CHANGES, chatName, connectStatus, COOLDOWN, cooldownEndDate, HEIGHT, intId, intIdNames, intIdPositions, onCooldown, PALETTE, PALETTE_USABLE_REGION, passkeyAuthState, placementMode, RAW_BOARD, setCooldown, setPasskeyAuthState, setPlacementMode, SOCKET_PIXELS, supportsCanvasPixelReports, WIDTH, placePixel, sendDefaultCaptchaResult, sendServerMessage, setDefaultCaptchaHandlers, makeServerRequest, connect } from "./game-state.js";
 import { generateIndicators, generatePalette, hideIndicators, showPalette } from "./palette.js";
 import { authenticatePasskey, getPasskeyStatus, registerPasskey, supportsPasskeys } from "./passkeys.js";
-import { isMention, normaliseBlockedUsers, isBlocked } from "./chat-helpers.js";
+import { findMentionQuery, formatMention, isMention, normaliseBlockedUsers, isBlocked } from "./chat-helpers.js";
 import "./popup.js";
 
 import FingerprintJS from "@fingerprintjs/fingerprintjs";
@@ -2124,7 +2124,11 @@ messageInput.addEventListener("keydown", function(/**@type {KeyboardEvent}*/ e) 
 	}
 
 	openChatPanel();
-	if (e.key == "Enter" && !e.shiftKey) {
+	if (e.key == "Escape" && !messageEmojisPanel.hasAttribute("closed")) {
+		closeMessageEmojisPanel();
+		e.preventDefault();
+	}
+	else if (e.key == "Enter" && !e.shiftKey) {
 		let sent = false;
 		// ctrl + enter send as place chat, enter send as normal live chat
 		if (e.ctrlKey) {
@@ -2155,15 +2159,7 @@ function chatInsertText(text) {
  * @param {number} senderId
  */
 function chatMentionUser(senderId) {
-	let mentionText = "@"
-	const identifier = intIdNames.get(senderId) || ("#" + senderId)
-	if (typeof identifier === "string") {
-		mentionText += identifier
-	}
-	else if (typeof identifier === "number") {
-		mentionText += "#" + identifier
-	}
-	chatInsertText(mentionText)
+	chatInsertText(formatMention(senderId) + " ")
 }
 
 messageTypePanel.children[0].addEventListener("click", function (/**@type {Event}*/e) {
@@ -2598,6 +2594,41 @@ function closeMessageEmojisPanel() {
 	messageInput.setAttribute("state", "default");
 }
 
+/** @param {{ query: string; start: number; end: number }} mentionQuery */
+function showMentionSuggestions(mentionQuery) {
+	const matches = Array.from(intIdNames.entries())
+		.filter(([userId, name]) => Number.isSafeInteger(userId) && userId > 0 &&
+			typeof name === "string" && name.toLowerCase().startsWith(mentionQuery.query))
+		.sort(([firstId, firstName], [secondId, secondName]) =>
+			firstName.localeCompare(secondName) || firstId - secondId)
+		.slice(0, 8);
+
+	for (const [userId, name] of matches) {
+		const entryElement = document.createElement("button");
+		entryElement.classList.add("message-emojis-suggestion", "message-mention-suggestion");
+		entryElement.title = `Mention @${name} as ${formatMention(userId)}`;
+
+		const entryLabel = document.createElement("span");
+		entryLabel.textContent = `@${name}`;
+		const entryId = document.createElement("small");
+		entryId.textContent = `#${userId}`;
+		entryElement.append(entryLabel, entryId);
+
+		entryElement.addEventListener("click", function() {
+			messageInput.setSelectionRange(mentionQuery.start, mentionQuery.end);
+			chatInsertText(formatMention(userId) + " ");
+			closeMessageEmojisPanel();
+			updateMessageInputHeight();
+		});
+		messageEmojisPanel.appendChild(entryElement);
+	}
+
+	if (matches.length === 0) return false;
+	messageInput.setAttribute("state", "command");
+	messageEmojisPanel.removeAttribute("closed");
+	return true;
+}
+
 let messageInputHeight = messageInput.scrollHeight
 function updateMessageInputHeight() {
 	messageInput.style.height = "0px";
@@ -2622,6 +2653,15 @@ messageInput.oninput = (/** @type {{ isTrusted: any; }} */ e) => {
 	updateMessageInputHeight();
 
 	messageEmojisPanel.innerHTML = "";
+	const mentionQuery = findMentionQuery(messageInput.value,
+		messageInput.selectionStart ?? messageInput.value.length);
+	if (mentionQuery) {
+		if (!showMentionSuggestions(mentionQuery)) {
+			closeMessageEmojisPanel();
+		}
+		return;
+	}
+
 	let comp = "";
 	let search = true;
 	let count = 0;

--- a/src/pages/index/index.js
+++ b/src/pages/index/index.js
@@ -1572,27 +1572,29 @@ const channelMentionCounts = new Map();
 function getChannelMentionCount(channel) {
 	return channelMentionCounts.get(channel) || 0;
 }
+function createBadgeElement(className) {
+	const badge = document.createElement("span");
+	badge.className = className;
+	badge.hidden = true;
+	return badge;
+}
 /** @param {HTMLElement} container @param {string} badgeId @returns {HTMLElement} */
 function ensureChannelBadge(container, badgeId) {
 	let badge = container.querySelector(`#${badgeId}`);
 	if (!badge) {
-		badge = document.createElement("span");
+		badge = createBadgeElement("channel-mention-badge");
 		badge.id = badgeId;
-		badge.className = "channel-mention-badge";
-		badge.hidden = true;
 		container.style.position = "relative";
 		container.appendChild(badge);
 	}
 	return badge;
 }
-/** @param {HTMLElement} li @returns {HTMLElement} */
-function ensureDropdownBadge(li) {
-	let badge = li.querySelector(".channel-mention-badge");
+/** @param {HTMLElement} listItem @returns {HTMLElement} */
+function ensureDropdownBadge(listItem) {
+	let badge = listItem.querySelector(".channel-mention-badge");
 	if (!badge) {
-		badge = document.createElement("span");
-		badge.className = "channel-mention-badge inline";
-		badge.hidden = true;
-		li.appendChild(badge);
+		badge = createBadgeElement("channel-mention-badge inline");
+		listItem.appendChild(badge);
 	}
 	return badge;
 }
@@ -3123,12 +3125,12 @@ replyUserButton.addEventListener("click", function(e) {
 })
 blockUserButton.addEventListener("click", function(e) {
 	if (targetedIntId == null) return;
-	const tid = Number(targetedIntId);
-	if (isBlocked(tid, blockedUsers)) {
-		blockedUsers.splice(blockedUsers.indexOf(tid), 1);
+	const normalisedTargetId = Number(targetedIntId);
+	if (isBlocked(normalisedTargetId, blockedUsers)) {
+		blockedUsers.splice(blockedUsers.indexOf(normalisedTargetId), 1);
 	}
-	else if (tid !== intId) {
-		blockedUsers.push(tid);
+	else if (normalisedTargetId !== intId) {
+		blockedUsers.push(normalisedTargetId);
 	}
 	localStorage.blocked = blockedUsers.join(",");
 	chatContext.style.display = "none";

--- a/src/pages/index/index.js
+++ b/src/pages/index/index.js
@@ -14,6 +14,7 @@ import { theme } from "./game-themes.js";
 import { BOARD, canvasLocked, CHANGES, chatName, connectStatus, COOLDOWN, cooldownEndDate, HEIGHT, intId, intIdNames, intIdPositions, onCooldown, PALETTE, PALETTE_USABLE_REGION, passkeyAuthState, placementMode, RAW_BOARD, setCooldown, setPasskeyAuthState, setPlacementMode, SOCKET_PIXELS, supportsCanvasPixelReports, WIDTH, placePixel, sendDefaultCaptchaResult, sendServerMessage, setDefaultCaptchaHandlers, makeServerRequest, connect } from "./game-state.js";
 import { generateIndicators, generatePalette, hideIndicators, showPalette } from "./palette.js";
 import { authenticatePasskey, getPasskeyStatus, registerPasskey, supportsPasskeys } from "./passkeys.js";
+import { isMention, normaliseBlockedUsers, isBlocked } from "./chat-helpers.js";
 import "./popup.js";
 
 import FingerprintJS from "@fingerprintjs/fingerprintjs";
@@ -1809,16 +1810,16 @@ function applyLiveChatMessageInteractivity(message, channel = "") {
 		chatModerate("delete", senderId, messageId, messageElement);
 	});
 
-	// Apply user blocking
-	if (message.senderIntId !== 0 && blockedUsers.includes(message.senderIntId)) {
+	// Apply user blocking — use normalised numeric list (see chat-helpers.js)
+	if (message.senderIntId !== 0 && isBlocked(message.senderIntId, blockedUsers)) {
 		message.style.color = "transparent";
 		message.style.textShadow = "0px 0px 6px black";
 	}
 
-	// Handle mentions
-	if (message.content.includes("@" + chatName) ||
-		message.content.includes("@#" + intId) ||
-		message.content.includes("@everyone")) {
+	// Handle mentions — pure helper, boundary-aware (chat-helpers.js)
+	// Edge: server censors @everyone/@here for non-admin/vip; censored payload
+	// will not match, so no notification — intentional current behaviour, documented.
+	if (isMention(message.content, chatName, intId)) {
 		message.setAttribute("mention", "true");
 		if (channel === currentChannel) {
 			runAudio(AUDIOS.closePalette);
@@ -2887,8 +2888,8 @@ overlayMenuOldCloseButton.addEventListener("click", function() {
 	overlayMenuOld.removeAttribute("open");
 });
 
-// Chat management
-let blockedUsers = localStorage.blocked?.split(",") || [];
+// Chat management — normalise to numbers to avoid string/number mismatch (old code stored ",")
+let blockedUsers = normaliseBlockedUsers(localStorage.blocked?.split(",") || []);
 /**@type {number|null}*/let targetedIntId = null;
 /**@type {number|null}*/let targetedMsgId = null;
 /**@type {number|null}*/let currentReplyId = null;
@@ -3020,7 +3021,7 @@ async function onChatContext(e, senderId, msgId) {
 		mentionUserButton.textContent = `${await translate("mention")} ${identifier}`;
 		replyUserButton.textContent = `${await translate("replyTo")} ${identifier}`;
 		blockUserButton.textContent =
-			`${await translate(blockedUsers.includes(senderId) ? "unblock" : "block")} ${identifier}`;
+			`${await translate(isBlocked(senderId, blockedUsers) ? "unblock" : "block")} ${identifier}`;
 
 		if (senderId == intId) {
 			blockUserButton.disabled = true;
@@ -3052,13 +3053,15 @@ replyUserButton.addEventListener("click", function(e) {
 	chatContext.style.display = "none";
 })
 blockUserButton.addEventListener("click", function(e) {
-	if (blockedUsers.includes(targetedIntId)) {
-		blockedUsers.splice(blockedUsers.indexOf(targetedIntId), 1);
+	if (targetedIntId == null) return;
+	const tid = Number(targetedIntId);
+	if (isBlocked(tid, blockedUsers)) {
+		blockedUsers.splice(blockedUsers.indexOf(tid), 1);
 	}
-	else if (targetedIntId != intId) {
-		blockedUsers.push(targetedIntId);
+	else if (tid !== intId) {
+		blockedUsers.push(tid);
 	}
-	localStorage.blocked = blockedUsers;
+	localStorage.blocked = blockedUsers.join(",");
 	chatContext.style.display = "none";
 });
 changeMyNameButton.addEventListener("click", function(e) {

--- a/src/pages/index/index.js
+++ b/src/pages/index/index.js
@@ -461,9 +461,10 @@ window.addEventListener("livechatmessage", (/**@type {Event}*/e) => {
 		message.reactions
 	);
 
-	// Apply interactivity to message element
 	applyLiveChatMessageInteractivity(newMessage, channel);
-
+	if (isMention(message.content, chatName, intId) && message.senderIntId !== intId && !isBlocked(message.senderIntId, blockedUsers)) {
+		incrementChannelMention(channel);
+	}
 	const atScrollBottom = chatMessages.scrollTop + chatMessages.offsetHeight + 64 >= chatMessages.scrollHeight;
 
 	// Update message storage
@@ -1566,6 +1567,71 @@ let extraLanguage = (lang == "en" ? "tr" : lang);
 	[extraLanguage, []],
 	["en", []]
 ]);
+const channelMentionCounts = new Map();
+function getChannelMentionCount(channel) {
+	return channelMentionCounts.get(channel) || 0;
+}
+function ensureChannelBadge(container, badgeId) {
+	let badge = container.querySelector(`#${badgeId}`);
+	if (!badge) {
+		badge = document.createElement("span");
+		badge.id = badgeId;
+		badge.className = "channel-mention-badge";
+		badge.hidden = true;
+		container.style.position = "relative";
+		container.appendChild(badge);
+	}
+	return badge;
+}
+function ensureDropdownBadge(li) {
+	let badge = li.querySelector(".channel-mention-badge");
+	if (!badge) {
+		badge = document.createElement("span");
+		badge.className = "channel-mention-badge inline";
+		badge.hidden = true;
+		li.appendChild(badge);
+	}
+	return badge;
+}
+function updateChannelBadges() {
+	const mineCount = getChannelMentionCount(extraLanguage);
+	const enCount = getChannelMentionCount("en");
+	const mineBadge = ensureChannelBadge(channelMineButton, "channelMineBadge");
+	mineBadge.textContent = mineCount > 99 ? "99+" : String(mineCount);
+	mineBadge.hidden = mineCount === 0;
+
+	const enBadge = ensureChannelBadge(channelEnButton, "channelEnBadge");
+	enBadge.textContent = enCount > 99 ? "99+" : String(enCount);
+	enBadge.hidden = enCount === 0;
+
+	const totalOthers = Array.from(channelMentionCounts.entries())
+		.filter(([ch]) => ch !== currentChannel)
+		.reduce((sum, [, n]) => sum + n, 0);
+	const dropParentBadge = ensureChannelBadge(channelDropParent, "channelDropBadge");
+	dropParentBadge.textContent = totalOthers > 99 ? "99+" : String(totalOthers);
+	dropParentBadge.hidden = totalOthers === 0;
+
+	for (const li of channelDropMenu.children) {
+		if (!(li instanceof HTMLElement)) continue;
+		const code = li.dataset.lang;
+		if (!code) continue;
+		const count = getChannelMentionCount(code);
+		const badge = ensureDropdownBadge(li);
+		badge.textContent = count > 99 ? "99+" : String(count);
+		badge.hidden = count === 0;
+	}
+}
+function incrementChannelMention(channel) {
+	if (!channel || channel === currentChannel) return;
+	channelMentionCounts.set(channel, (channelMentionCounts.get(channel) || 0) + 1);
+	updateChannelBadges();
+}
+function clearChannelMentions(channel) {
+	if (channelMentionCounts.has(channel)) {
+		channelMentionCounts.delete(channel);
+		updateChannelBadges();
+	}
+}
 let chatPreviousLoadDebounce = false;
 let chatPreviousAutoLoad = false;
 let currentChannel = lang;
@@ -1656,6 +1722,7 @@ function switchLanguageChannel(selected) {
 		chatCancelReplies()
 	}
 	currentChannel = selected
+	clearChannelMentions(selected);
 	chatMessages.style.direction = (LANG_INFOS.get(selected)?.rtl) ? "rtl" : "ltr"
 
 	if (selected == "en") {
@@ -1816,12 +1883,9 @@ function applyLiveChatMessageInteractivity(message, channel = "") {
 		message.style.textShadow = "0px 0px 6px black";
 	}
 
-	// Handle mentions — pure helper, boundary-aware (chat-helpers.js)
-	// Edge: server censors @everyone/@here for non-admin/vip; censored payload
-	// will not match, so no notification — intentional current behaviour, documented.
 	if (isMention(message.content, chatName, intId)) {
 		message.setAttribute("mention", "true");
-		if (channel === currentChannel) {
+		if (message.senderIntId !== intId && !isBlocked(message.senderIntId, blockedUsers)) {
 			runAudio(AUDIOS.closePalette);
 		}
 	}

--- a/src/pages/index/index.js
+++ b/src/pages/index/index.js
@@ -1568,9 +1568,11 @@ let extraLanguage = (lang == "en" ? "tr" : lang);
 	["en", []]
 ]);
 const channelMentionCounts = new Map();
+/** @param {string} channel @returns {number} */
 function getChannelMentionCount(channel) {
 	return channelMentionCounts.get(channel) || 0;
 }
+/** @param {HTMLElement} container @param {string} badgeId @returns {HTMLElement} */
 function ensureChannelBadge(container, badgeId) {
 	let badge = container.querySelector(`#${badgeId}`);
 	if (!badge) {
@@ -1583,6 +1585,7 @@ function ensureChannelBadge(container, badgeId) {
 	}
 	return badge;
 }
+/** @param {HTMLElement} li @returns {HTMLElement} */
 function ensureDropdownBadge(li) {
 	let badge = li.querySelector(".channel-mention-badge");
 	if (!badge) {
@@ -1621,11 +1624,13 @@ function updateChannelBadges() {
 		badge.hidden = count === 0;
 	}
 }
+/** @param {string} channel */
 function incrementChannelMention(channel) {
 	if (!channel || channel === currentChannel) return;
 	channelMentionCounts.set(channel, (channelMentionCounts.get(channel) || 0) + 1);
 	updateChannelBadges();
 }
+/** @param {string} channel */
 function clearChannelMentions(channel) {
 	if (channelMentionCounts.has(channel)) {
 		channelMentionCounts.delete(channel);

--- a/styles.css
+++ b/styles.css
@@ -1251,6 +1251,48 @@ body[eventphase="3"] .coverer-title {
 	background-color: #ffff0080;
 }
 
+r-live-chat-message .chat-mention {
+	color: var(--reddit-orange);
+	cursor: help;
+	text-decoration: underline dotted;
+	text-underline-offset: 2px;
+}
+
+r-live-chat-message .chat-mention:focus-visible {
+	border-radius: 2px;
+	outline: 2px solid var(--reddit-orange);
+	outline-offset: 1px;
+}
+
+.chat-mention-popover {
+	display: none;
+	flex-direction: column;
+	gap: 2px;
+	padding: 6px 8px;
+	border: 1px solid var(--ui-panel-hover, #aaa);
+	border-radius: 4px;
+	background: var(--ui-panel-bg, white);
+	color: var(--ui-text, black);
+	box-shadow: var(--ui-shadow, 0 2px 8px #0005);
+	font-family: mono;
+	font-size: 12px;
+	white-space: nowrap;
+	pointer-events: none;
+}
+
+.chat-mention-popover:popover-open {
+	display: flex;
+}
+
+@supports (position-area: block-end) {
+	.chat-mention-popover:popover-open {
+		inset: auto;
+		margin: 4px;
+		position-area: block-end span-inline-end;
+		position-try-fallbacks: flip-block, flip-inline;
+	}
+}
+
 .chat-message-list > .message[reply] {
 	background-color: #e4efff;
 }
@@ -1470,6 +1512,9 @@ body[eventphase="3"] .coverer-title {
 	align-self: center;
 	text-align: left;
 	text-align: left;
+}
+.message-mention-suggestion > small {
+	opacity: 0.7;
 }
 #messageReplyPanel {
 	height: calc(var(--message-input-height) + 48px);

--- a/styles.css
+++ b/styles.css
@@ -1111,6 +1111,7 @@ body[eventphase="3"] .coverer-title {
 
 .message-input-actions {
 	position: absolute;
+	z-index: 3;
 	right: 2px;
 	top: 0;
 	height: 36px;
@@ -1128,8 +1129,34 @@ body[eventphase="3"] .coverer-title {
 }
 
 #messageInput {
+	position: relative;
+	z-index: 1;
 	resize: none;
 	width: 100%;
+}
+
+#messageInputMirror {
+	position: absolute;
+	inset: 0;
+	z-index: 2;
+	width: 100%;
+	height: 100%;
+	box-sizing: border-box;
+	overflow: hidden;
+	color: transparent;
+	font-size: 16px;
+	line-height: normal;
+	white-space: pre-wrap;
+	overflow-wrap: break-word;
+	pointer-events: none;
+	user-select: none;
+}
+
+#messageInputMirror .linked-mention {
+	background: rgba(255, 87, 0, 0.2);
+	background: color-mix(in srgb, var(--reddit-orange) 20%, transparent);
+	border-radius: 2px;
+	box-shadow: inset 0 -2px var(--reddit-orange);
 }
 
 .chat-bottom-panel {

--- a/styles.css
+++ b/styles.css
@@ -1320,6 +1320,34 @@ body[eventphase="3"] .coverer-title {
 	padding: 0;	
 }
 
+.channel-mention-badge {
+	position: absolute;
+	top: -6px;
+	right: -6px;
+	min-width: 16px;
+	height: 16px;
+	padding: 0 4px;
+	border-radius: 999px;
+	background: var(--reddit-orange);
+	color: white;
+	font-size: 10px;
+	line-height: 16px;
+	text-align: center;
+	pointer-events: none;
+	z-index: 1;
+}
+
+.channel-mention-badge.inline {
+	position: static;
+	margin-left: auto;
+	top: auto;
+	right: auto;
+}
+
+#channelDropMenu > li {
+	position: relative;
+}
+
 #captchaPopup {
 	width: 450px;
 	height: fit-content;


### PR DESCRIPTION
Related to #369, “Notify user of @ mentions from across language channels”.

This branch includes the cross-channel @mention badge, counter, and sound work tracked by #369, plus the linked vanity-name composer follow-up. The composer keeps readable @name text visible while serializing canonical @#intId references for live-chat delivery.

- Adds contiguous-edit token rebasing and fail-safe invalidation.
- Adds a mirrored, aria-hidden composer layer for linked mention highlights.
- Serializes intact tokens before live-chat sends.
- Keeps native textarea, IME, selection behavior, and the existing worker/server protocol.
- Adds helper tests.

Verification:
- bun test (46 passing)
- bun run build
- git diff --check

Place-chat Ctrl+Enter intentionally remains outside canonical live-chat serialization scope.